### PR TITLE
Fix homepage link to old ASCII page

### DIFF
--- a/index.html
+++ b/index.html
@@ -739,7 +739,7 @@
                             <div style="text-align: center; margin-bottom: 20px;">
                                 <h3 style="color: #ffffff; margin-bottom: 15px;">Explore the Original World</h3>
                                 <p style="margin-bottom: 20px;">Experience the ASCII art world map that was the original homepage design.</p>
-                                <a href="./old homepage 6.4.html" style="
+                                <a href="./Save%20files/old%20homepage%206.4.html" style="
                                     display: inline-block;
                                     padding: 10px 20px;
                                     background: linear-gradient(135deg, #3a3a5a, #2a2a4a);


### PR DESCRIPTION
## Summary
- correct the link to the "old homepage" so it points to the file in the `Save files` directory

## Testing
- `npx -y htmlhint index.html`

------
https://chatgpt.com/codex/tasks/task_e_684727e599a083328b2ef2b978152aa7