### PR TITLE
Add responsive mobile layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,8 @@
             display: flex;
             align-items: center;
             justify-content: center;
-        }/* PS1 Square Viewport Container */
+        }
+        /* PS1 Square Viewport Container */
         .ps1-viewport {
             width: min(80vh, 80vw);
             height: min(60vh, 60vw);
@@ -333,7 +334,45 @@
                 flex: 1;
                 margin-bottom: 0;
             }
-        }        /* PS1 Scanline and CRT Effects - Only within viewport */
+        }
+        /* Mobile layout overhaul */
+        @media (max-width: 480px) {
+            body, html {
+                font-size: 18px;
+            }
+
+            .ps1-viewport {
+                width: 100vw;
+                height: auto;
+                max-width: none;
+                max-height: none;
+            }
+
+            .ffix-layout {
+                flex-direction: column;
+            }
+
+            .character-area {
+                width: 100%;
+                height: auto;
+                border-right: none;
+                border-bottom: 2px solid #B0B0B0;
+            }
+
+            .menu-area {
+                width: 100%;
+                height: auto;
+                flex-direction: column;
+            }
+
+            .command-menu,
+            .time-gil-box,
+            .location-box {
+                margin-bottom: 8px;
+            }
+        }
+
+        /* PS1 Scanline and CRT Effects - Only within viewport */
         .ps1-scanlines {
             position: absolute;
             top: 0;
@@ -403,7 +442,8 @@
         .time-gil-box,
         .location-box {
             filter: contrast(1.2) saturate(0.8);
-        }        /* PS1 text rendering effects */
+        }
+        /* PS1 text rendering effects */
         .character-name,
         .content-header,
         .menu-item,


### PR DESCRIPTION
## Summary
- overhaul the layout for small screens
- ensure mobile viewport uses full width and height

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6849fdefc858833291da9d64d165d60a