### PR TITLE
Add animated cursor to Benji page

### DIFF
--- a/benji's site/benji.html
+++ b/benji's site/benji.html
@@ -205,6 +205,22 @@
             background: linear-gradient(135deg, #3A3A5A, #2A2A4A);
         }
 
+        /* Pointer (FF9 hand cursor) */
+        #pointer {
+            position: absolute;
+            width: 140px;
+            height: 105px;
+            background-image: url('./cursor.png');
+            background-size: contain;
+            background-repeat: no-repeat;
+            left: -45px;
+            transition: top 0.15s ease;
+            z-index: 10;
+            pointer-events: none;
+            image-rendering: pixelated;
+            transform: translateY(-15px);
+        }
+
         /* Content Sections */
         .content-section {
             background: linear-gradient(135deg, #3B3E45, #2F2F2F);
@@ -349,6 +365,7 @@
         <div class="content-wrapper">
             <div class="ffix-layout">
                 <div class="main-area">
+                    <div id="pointer"></div>
                     <!-- Character Header -->
                     <div class="character-header">                        <div class="character-portrait" id="benjiPortrait">
                         </div>
@@ -452,12 +469,64 @@
                 this.pauseBtn = document.getElementById('pauseBtn');
                 this.musicStatus = document.getElementById('musicStatus');
                 this.isPlaying = false;
-                
+
+                this.pointer = document.getElementById('pointer');
+                this.mainArea = document.querySelector('.main-area');
+                this.listItems = document.querySelectorAll('.favorites-list li');
+                this.currentIndex = 0;
+
+                this.cursorSound = new Audio('../Final Fantasy IX (PS1) - Cut Menu Cursor Sound.mp3');
+                this.cursorSound.volume = 0.3;
+                this.cursorSound.preload = 'auto';
+                this.soundPlaying = false;
+
                 this.init();
             }
 
             init() {
                 this.setupMusicPlayer();
+                this.updatePointer();
+                this.startPointerLoop();
+            }
+
+            updatePointer() {
+                const item = this.listItems[this.currentIndex];
+                if (item && this.pointer && this.mainArea) {
+                    const itemRect = item.getBoundingClientRect();
+                    const areaRect = this.mainArea.getBoundingClientRect();
+                    this.pointer.style.left = (itemRect.left - areaRect.left - 45) + 'px';
+                    this.pointer.style.top = (itemRect.top - areaRect.top + itemRect.height / 2 - 37) + 'px';
+                }
+            }
+
+            startPointerLoop() {
+                if (this.listItems.length === 0) return;
+                setInterval(() => {
+                    this.currentIndex = (this.currentIndex + 1) % this.listItems.length;
+                    this.updatePointer();
+                    this.playCursorSound();
+                }, 1500);
+            }
+
+            playCursorSound() {
+                try {
+                    if (this.soundPlaying) {
+                        this.cursorSound.pause();
+                        this.cursorSound.currentTime = 0;
+                    }
+                    this.soundPlaying = true;
+                    const playPromise = this.cursorSound.play();
+                    if (playPromise !== undefined) {
+                        playPromise.catch(err => {
+                            console.debug('Audio play prevented:', err);
+                            this.soundPlaying = false;
+                        });
+                    }
+                    this.cursorSound.onended = () => { this.soundPlaying = false; };
+                } catch (e) {
+                    console.debug('Cursor sound error:', e);
+                    this.soundPlaying = false;
+                }
             }
 
             setupMusicPlayer() {
@@ -523,7 +592,9 @@
                     console.log('Play error:', error);
                     this.musicStatus.textContent = 'Unable to play music - ' + error.message;
                 }
-            }            pauseMusic() {
+            }
+
+            pauseMusic() {
                 this.bgMusic.pause();
             }
         }


### PR DESCRIPTION
## Summary
- add FFIX cursor styling
- include cursor overlay for Benji's page
- animate cursor through list items and play sound

## Testing
- `node -e "require('fs').readFileSync('benji\'s site/benji.html','utf8'); console.log('ok');"`

------
https://chatgpt.com/codex/tasks/task_e_684b2279b294833283c84600dce06c94