### PR TITLE
Add cursor sound on menu selection

### DIFF
--- a/main-site/index.html
+++ b/main-site/index.html
@@ -1164,6 +1164,7 @@
                     item.addEventListener('click', () => {
                         this.currentMenuItem = index;
                         this.updateActiveItem();
+                        this.playCursorSound();
                         this.updateContent();
                     });
                     
@@ -1184,6 +1185,7 @@
                         // Find the Status menu item (index 0) and simulate clicking it
                         this.currentMenuItem = 0; // Status is the first menu item
                         this.updateActiveItem();
+                        this.playCursorSound();
                         this.updateContent();
                     });
                 }
@@ -1200,6 +1202,7 @@
             }
 
             selectCurrentItem() {
+                this.playCursorSound();
                 this.updateContent();
             }
 


### PR DESCRIPTION
## Summary
- trigger cursor audio when selecting menu items via mouse click, Enter key, or panel click

## Testing
- `pytest` (no tests found)
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684b340375408332a173db7e0e48dad8