### PR TITLE
Fix closing pop up by clicking outside

### DIFF
--- a/main-site/index.html
+++ b/main-site/index.html
@@ -1198,6 +1198,15 @@
                         this.updateContent();
                     });
                 }
+
+                // Close modal when clicking outside of it
+                document.addEventListener('click', (event) => {
+                    if (this.modalOpen &&
+                        !this.contentModal.contains(event.target) &&
+                        !event.target.closest('.menu-item')) {
+                        this.closeModal();
+                    }
+                });
             }            navigateUp() {
                 this.currentMenuItem = (this.currentMenuItem - 1 + this.menuItems.length) % this.menuItems.length;
                 this.updateActiveItem();


### PR DESCRIPTION
## Summary
- add click-outside listener to close modals on the main page

## Testing
- `npx htmlhint main-site/index.html` *(fails: requires network to install package)*

------
https://chatgpt.com/codex/tasks/task_e_684b4eaa9a408332929ba5975afea660