### PR TITLE
Fix resume download link

### DIFF
--- a/main-site/index.html
+++ b/main-site/index.html
@@ -1037,7 +1037,7 @@
                         title: 'Resume',
                         content: `
                             <div style="text-align: center; margin-bottom: 15px; padding-bottom: 10px; border-bottom: 1px solid #B0B0B0;">
-                                <a href="./resume/Peter Baumgartner.docx" download="Peter_Baumgartner_Resume.docx" style="
+                                <a href="../resume/Peter Baumgartner.docx" download="Peter_Baumgartner_Resume.docx" style="
                                     display: inline-block;
                                     padding: 6px 12px;
                                     background: linear-gradient(135deg, #3a3a5a, #2a2a4a);


### PR DESCRIPTION
## Summary
- fix resume download link path in main site index

## Testing
- `npm test` *(fails: Could not read package.json)*
- `curl -sI http://localhost:8000/main-site/index.html`
- `curl -sI http://localhost:8000/resume/Peter%20Baumgartner.docx`

------
https://chatgpt.com/codex/tasks/task_e_68b0a3e60edc83329aafeedce8faa737