### PR TITLE
Remove placeholder forward simulator page

### DIFF
--- a/main-site/index.html
+++ b/main-site/index.html
@@ -954,19 +954,6 @@
                             <p>Magic in the digital age isn't about illusion—it's about creating experiences that inspire wonder, curiosity, and joy. Through creative coding and interactive design, I craft digital spells that bring ideas to life.</p>
                         `
                     },
-                    sim: {
-                        title: 'FORWARD sim. [WIP]',
-                        content: `
-                            <div style="text-align: center; margin-bottom: 20px;">
-                                <h3 style="color: #ffffff; margin-bottom: 15px;">🕹️ FORWARD sim. [WIP]</h3>
-                                <p style="margin-bottom: 20px;">Prototype web implementation of the FORWARD dungeon crawl rule set.</p>
-                                <!-- Updated path (removed space) & cache-bust param -->
-                                <a href="../forward-sim/index.html?v=2025-08-14-a" style="
-                                    display:inline-block; padding:12px 24px; background:linear-gradient(135deg,#3a3a5a,#2a2a4a); border:1px solid #5a5a7a; border-radius:4px; color:#ffffff; text-decoration:none; font-size:12px;">Open Simulator</a>
-                            </div>
-                            <p>This opens in a separate page so you can continue exploring after testing a run.</p>
-                        `
-                    },
                     photos: {
                         title: 'Photos',
                         content: `


### PR DESCRIPTION
## Summary
- delete placeholder forward simulator page and supporting link

## Testing
- `npm test` *(fails: Could not read package.json: ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a3de29fc8332bca7379b73ae5d84