### PR TITLE
Extract StoneBGMPlayer to shared script

### DIFF
--- a/assets/js/bgm-player.js
+++ b/assets/js/bgm-player.js
@@ -1,0 +1,53 @@
+class StoneBGMPlayer {
+    constructor(audioPath = 'Stone.mp3') {
+        this.bgmBox = document.getElementById('bgm-box');
+        this.stoneMusic = new Audio(audioPath);
+        this.stoneMusic.volume = 0.4;
+        this.isPlaying = false;
+        this.init();
+    }
+
+    init() {
+        this.bgmBox.addEventListener('click', () => {
+            if (this.isPlaying) {
+                this.pauseMusic();
+            } else {
+                this.playMusic();
+            }
+        });
+
+        this.stoneMusic.addEventListener('ended', () => {
+            this.isPlaying = false;
+            this.updateUI();
+        });
+    }
+
+    playMusic() {
+        const playPromise = this.stoneMusic.play();
+
+        if (playPromise !== undefined) {
+            playPromise.then(() => {
+                this.isPlaying = true;
+                this.updateUI();
+            }).catch(err => {
+                console.debug('Stone music play prevented:', err);
+            });
+        }
+    }
+
+    pauseMusic() {
+        this.stoneMusic.pause();
+        this.isPlaying = false;
+        this.updateUI();
+    }
+
+    updateUI() {
+        if (this.isPlaying) {
+            this.bgmBox.querySelector('.location-name').textContent = 'Toggle BGM';
+            this.bgmBox.style.background = 'linear-gradient(135deg, #4A4A4A, #3A3A3A)';
+        } else {
+            this.bgmBox.querySelector('.location-name').textContent = 'Toggle BGM';
+            this.bgmBox.style.background = 'linear-gradient(135deg, #3B3E45, #2F2F2F)';
+        }
+    }
+}

--- a/index.html
+++ b/index.html
@@ -631,6 +631,7 @@
         <div class="loading-percentage" id="loadingPercentage">0%</div>
     </div>
 
+    <script src="assets/js/bgm-player.js"></script>
     <script>        class FFIXMenu {
             constructor() {
                 this.currentMenuItem = 0;
@@ -1456,71 +1457,12 @@
                 };
                 render();
             }        }
-        
-        // Stone BGM Player
-        class StoneBGMPlayer {
-            constructor() {
-                this.bgmBox = document.getElementById('bgm-box');
-                this.stoneMusic = new Audio('Stone.mp3');
-                this.stoneMusic.volume = 0.4;
-                this.isPlaying = false;
-                
-                // Initialize event listeners
-                this.init();
-            }
-            
-            init() {
-                // Click to play/pause
-                this.bgmBox.addEventListener('click', () => {
-                    if (this.isPlaying) {
-                        this.pauseMusic();
-                    } else {
-                        this.playMusic();
-                    }
-                });
-                
-                // Update UI when music ends
-                this.stoneMusic.addEventListener('ended', () => {
-                    this.isPlaying = false;
-                    this.updateUI();
-                });
-            }
-            
-            playMusic() {
-                const playPromise = this.stoneMusic.play();
-                
-                if (playPromise !== undefined) {
-                    playPromise.then(() => {
-                        this.isPlaying = true;
-                        this.updateUI();
-                    }).catch(err => {
-                        console.debug('Stone music play prevented:', err);
-                    });
-                }
-            }
-            
-            pauseMusic() {
-                this.stoneMusic.pause();
-                this.isPlaying = false;
-                this.updateUI();
-            }
-              updateUI() {
-                if (this.isPlaying) {
-                    this.bgmBox.querySelector('.location-name').textContent = 'Toggle BGM';
-                    this.bgmBox.style.background = 'linear-gradient(135deg, #4A4A4A, #3A3A3A)';
-                } else {
-                    this.bgmBox.querySelector('.location-name').textContent = 'Toggle BGM';
-                    this.bgmBox.style.background = 'linear-gradient(135deg, #3B3E45, #2F2F2F)';
-                }
-            }
-        }
-
         // Initialize PS1 effects
         document.addEventListener('DOMContentLoaded', () => {
             try {
                 window.ffixMenu = new FFIXMenu();
                 window.ps1Effects = new PS1Effects();
-                window.stoneBGM = new StoneBGMPlayer();
+                window.stoneBGM = new StoneBGMPlayer('Stone.mp3');
             } catch (error) {
                 console.error('Error initializing site:', error);
                 // Fallback: at least show the basic menu without effects

--- a/main-site/index.html
+++ b/main-site/index.html
@@ -631,6 +631,7 @@
         <div class="loading-percentage" id="loadingPercentage">0%</div>
     </div>
 
+    <script src="../assets/js/bgm-player.js"></script>
     <script>        class FFIXMenu {
             constructor() {
                 this.currentMenuItem = 0;
@@ -1408,71 +1409,12 @@
                 };
                 render();
             }        }
-        
-        // Stone BGM Player
-        class StoneBGMPlayer {
-            constructor() {
-                this.bgmBox = document.getElementById('bgm-box');
-                this.stoneMusic = new Audio('../Stone.mp3');
-                this.stoneMusic.volume = 0.4;
-                this.isPlaying = false;
-                
-                // Initialize event listeners
-                this.init();
-            }
-            
-            init() {
-                // Click to play/pause
-                this.bgmBox.addEventListener('click', () => {
-                    if (this.isPlaying) {
-                        this.pauseMusic();
-                    } else {
-                        this.playMusic();
-                    }
-                });
-                
-                // Update UI when music ends
-                this.stoneMusic.addEventListener('ended', () => {
-                    this.isPlaying = false;
-                    this.updateUI();
-                });
-            }
-            
-            playMusic() {
-                const playPromise = this.stoneMusic.play();
-                
-                if (playPromise !== undefined) {
-                    playPromise.then(() => {
-                        this.isPlaying = true;
-                        this.updateUI();
-                    }).catch(err => {
-                        console.debug('Stone music play prevented:', err);
-                    });
-                }
-            }
-            
-            pauseMusic() {
-                this.stoneMusic.pause();
-                this.isPlaying = false;
-                this.updateUI();
-            }
-              updateUI() {
-                if (this.isPlaying) {
-                    this.bgmBox.querySelector('.location-name').textContent = 'Toggle BGM';
-                    this.bgmBox.style.background = 'linear-gradient(135deg, #4A4A4A, #3A3A3A)';
-                } else {
-                    this.bgmBox.querySelector('.location-name').textContent = 'Toggle BGM';
-                    this.bgmBox.style.background = 'linear-gradient(135deg, #3B3E45, #2F2F2F)';
-                }
-            }
-        }
-
         // Initialize PS1 effects
         document.addEventListener('DOMContentLoaded', () => {
             try {
                 window.ffixMenu = new FFIXMenu();
                 window.ps1Effects = new PS1Effects();
-                window.stoneBGM = new StoneBGMPlayer();
+                window.stoneBGM = new StoneBGMPlayer('../Stone.mp3');
             } catch (error) {
                 console.error('Error initializing site:', error);
                 // Fallback: at least show the basic menu without effects


### PR DESCRIPTION
## Summary
- move StoneBGMPlayer into reusable assets/js/bgm-player.js
- load shared script from index.html and main-site/index.html
- initialize StoneBGMPlayer with appropriate audio paths on each page

## Testing
- `node - <<'NODE'
const fs = require('fs');
const vm = require('vm');
const context={document:{getElementById:()=>({addEventListener:()=>{},querySelector:()=>({textContent:'',style:{}}),style:{}})},Audio:function(){this.volume=0;this.play=()=>Promise.resolve();this.pause=()=>{};this.addEventListener=()=>{};},console};
vm.createContext(context);
const scriptContent=fs.readFileSync('./assets/js/bgm-player.js','utf8');
const StoneBGMPlayer=vm.runInContext('(' + scriptContent + ')',context);
new StoneBGMPlayer('Stone.mp3');
new StoneBGMPlayer('../Stone.mp3');
console.log('StoneBGMPlayer initialized with both paths');
NODE`
- `npm test` *(fails: ENOENT could not read package.json)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b0b2b60020833285eaa459bd4963eb