### PR TITLE
Clarify Snare placement and cleansing

### DIFF
--- a/forward/forward rules.md
+++ b/forward/forward rules.md
@@ -94,6 +94,7 @@ On your turn, perform the following; if a card contradicts these rules, follow t
 2) Resolve its text completely.
    – If it stays with you (Item/Equipment/Companion/Boon), place it in your Player Zone
      (respect limits printed on your Player card or the card itself).
+   – If it's a Snare, leave it in your Player Zone or a dedicated Snare area (see 9.1). It remains until cleansed or otherwise removed.
    – If it does not stay, place it on the Discard.
    – If it says bury, place it face-down in the global BURIED pile.
    – If it references Resolve/Dread, move your marker accordingly.
@@ -117,7 +118,7 @@ Rules notes
 • Item / Equipment / Boon — Kept in your Player Zone; may grant stats, uses, or text effects.
 • Companion / Ally — Kept in your Player Zone; abilities or single-use powers.
 • Scene / Rest — Immediate effects; usually go to Discard after resolving.
-• Hazard / Pit / Snare / Challenge — Tests that can cost HP, cards, Resolve, time, etc.
+• Hazard / Pit / Snare / Challenge — Tests that can cost HP, cards, Resolve, time, etc. Revealed Snares stay in your Player Zone until cleansed (see 9.1).
 • Combat / Beast / Hollow — Fights using the Duel System (Section 7).
 • Treasure / Reward / Blessing — Immediate benefits or persistent keepers.
 • Terror — Hard choices or escalating pressure (often interacts with Dread).
@@ -162,6 +163,10 @@ High Resolve and high Dread effects live on the cards themselves.
 • If a limit is exceeded, immediately discard or bury down to the limit, as directed
   by your Player card or the exceeding card’s text.
 • Spent or broken cards will say how and when they leave play.
+
+9.1 Snares
+• When revealed, a Snare stays face-up in your Player Zone or a dedicated Snare area until cleansed or otherwise removed.
+• Effects that say “Cleanse 1 Snare” let you choose one of your revealed Snares. Discard it and ignore its ongoing effects.
 
 ================================================================================
 10) RESTS, SCENES, & CHECKPOINTS


### PR DESCRIPTION
## Summary
- Explain that revealed Snare cards stay in the player zone (or Snare area) until removed
- Clarify that “Cleanse 1 Snare” effects discard a chosen Snare and negate its effect
- Cross-reference Snare handling in turn structure and card types sections

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b387e560c883329fcbeec031cfceb6