### PR TITLE
Add quick start reference and clarify bug fight ownership

### DIFF
--- a/bug-hunt/8.28.25 EOD bug hunt rules.md
+++ b/bug-hunt/8.28.25 EOD bug hunt rules.md
@@ -46,9 +46,9 @@ Players act simultaneously. On your go (any time during the Day):
 2. Spend movement to move to adjacent hexes; each hex has a movement cost of 1, 2, or 3.
 3. If you enter a hex with a bug, you must stop and Fight it; any unspent movement is lost.
 
-You cannot move through a hex containing another player’s current fight. You may pass through other players otherwise.
+You cannot move through or enter a hex containing another player’s current fight. Once a Hunter engages a bug, no one else may join, assist, or interfere; wait for the fight to resolve. You may pass through other players otherwise.
 
-Claiming a Bug (simultaneous arrivals): The first pawn to fully enter the bug’s hex claims the fight. If truly simultaneous, both players roll 1d6; highest claims (reroll ties).
+Claiming a Bug (simultaneous arrivals): The first pawn to fully enter the bug’s hex claims the fight. If truly simultaneous, both players roll 1d6; highest claims (reroll ties). The other player stays outside the hex; only the winner may fight the bug.
 
 ## Fighting Bugs
 
@@ -112,7 +112,6 @@ Once you confirm these, I’ll lock defaults, tune the appendix, and add a print
 
 - Tougher Progression: As Days advance, increase Sting severity by +1 on Day 2 and +2 on Day 3.
 - Refill by Re‑Pour: At the end of each Day, scoop all remaining bugs into the cup, add new tokens if desired, shake, and re‑pour to refresh distribution.
-- Team-Up Assist: Two players sharing a bug’s hex may alternate rolls; both suffer Sting on their own 1s. Only one player claims the token; decide before the fight.
 - Terrain Hazards: Rivers or cliffs cost 3 movement to enter and cannot be ended upon unless you defeat a bug there.
 
 ### Items and Shop
@@ -137,4 +136,26 @@ At the start of Day 3, spawn the Queen Bee at the Hive (marked space). All playe
 - Queen Bee (prototype): HP 40, Sting 6, Category Flying/Armored.
 - Splash Sting: When any player rolls a 1 against the Queen, all adjacent players also take 1 Sting damage.
 - Reward: Defeating the Queen grants a +5 bonus to every participating player.
+ 
+## Quick Start Reference
+
+**Setup**
+- Scatter Small ×10, Medium ×5, and Large ×3 bug tokens across the map.
+- Each Hunter starts at the Village with 10 HP and sets a 3‑minute Day timer.
+
+**During the Day**
+- Roll 1d6 for movement; spend points to enter adjacent hexes.
+- Entering a bug’s hex ends movement. Fight until you defeat it or the timer ends.
+- Combat: roll 1d6 repeatedly — Small 4+, Medium 5+, Large 6+. On any 1, take 1 damage.
+- After a win, take the bug token and score its points, then roll again to move.
+
+**Restrictions**
+- Only one Hunter may fight a bug at a time; others must wait outside.
+- You cannot move through or enter another player’s fight hex.
+
+**End of Day**
+- When the timer ends, stop immediately. Score bugs you’ve already defeated and reset for the next Day.
+
+**Win**
+- After three Days, highest total points wins. Tie‑breakers: most Large bugs, then most total bugs.
 


### PR DESCRIPTION
## Summary
- Add a compact Quick Start reference at the end of Bug Hunt rules
- Clarify that only one hunter can engage a bug at a time and others must wait
- Remove team-up assist variant to prevent simultaneous captures

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b386b603048332851267d4189c0810