### PR TITLE
Clarify tie-break rules for Bug Hunt

### DIFF
--- a/bug-hunt/8.28.25 EOD bug hunt rules.md
+++ b/bug-hunt/8.28.25 EOD bug hunt rules.md
@@ -1,6 +1,6 @@
 # Bug Hunt — Rules (Draft)
 
-This is a first playable draft distilled from the 8.28.25 design notes. Assumptions are marked with [ASSUMPTION] and questions with [Q] for your confirmation.
+This is a first playable draft distilled from the 8.28.25 design notes.
 
 ## Overview
 
@@ -82,7 +82,7 @@ After defeating a bug, immediately take its token and gain its points. Roll agai
 
 - Keep collected bug tokens face up; their points count immediately.
 - Points carry over between Days.
-- Highest total after Day 3 wins. Ties: most Large bugs collected, then most total bugs. [ASSUMPTION]
+- Highest total after Day 3 wins. Ties are broken by: most Large bugs collected, then most total bugs. If still tied, each tied player places a Large bug on the map, a countdown is called, and all roll simultaneously—the first to defeat their bug wins.
 
 <!-- Endgame and detailed roster moved to Appendix -->
 
@@ -93,6 +93,8 @@ After defeating a bug, immediately take its token and gain its points. Roll agai
 - Move: You roll a 5. You travel a 1‑cost, 1‑cost, then 3‑cost hex (1+1+3=5) and end on a Medium bug. You must fight.
 - Fight (Basic): Medium needs 5+. You roll 1 (Sting: take 1 damage), then 6 (success) — you defeat it and take 2 points.
 - KO: You hit 0 HP; you reset to Village/Camp immediately. No token loss or skipped turn; resume next round.
+- Tie-break: Alex and Bailey tie at 7 points. Alex has two Large bugs to Bailey's one, so Alex wins.
+- Tie-break (still tied): Carla and Devon remain tied after comparing Large and total bugs. They each start on a Large bug, count "One, two, three," and roll together—Carla wins after two rolls when Devon needs three.
 
 ---
 


### PR DESCRIPTION
## Summary
- Confirm tie-break procedure and remove `[ASSUMPTION]` note
- Provide example scenarios showing how ties are resolved

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b386815c64833289eb3cc40ed26658