### PR TITLE
Clarify knockout recovery in bug hunt rules

### DIFF
--- a/bug-hunt/8.28.25 EOD bug hunt rules.md
+++ b/bug-hunt/8.28.25 EOD bug hunt rules.md
@@ -67,7 +67,7 @@ After defeating a bug, immediately take its token and gain its points. Roll agai
 ## Player Health and Knockout
 
 - Each Hunter starts at 10 HP.
-- If your HP is reduced to 0, you’re Knocked Out: immediately return to the Village/Camp at full HP. Your current action ends; there’s no further penalty and you keep all collected bug tokens.
+- If your HP is reduced to 0, you’re Knocked Out: immediately return to the Village/Camp at full HP. Your current action ends; there’s no further penalty and you keep all collected bug tokens. Resume movement right away from the Village with a fresh roll.
 
 
 ## Bug List (Basic)


### PR DESCRIPTION
## Summary
- clarify that knocked-out players resume movement immediately from the Village with a fresh roll

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b38634b87c8332ae9723e1c7e1760b