### PR TITLE
Add movement flow summary to bug hunt rules

### DIFF
--- a/bug-hunt/8.28.25 EOD bug hunt rules.md
+++ b/bug-hunt/8.28.25 EOD bug hunt rules.md
@@ -40,11 +40,14 @@ Have the highest total points after Day 3.
 
 ## Real‑Time Play
 
-Players act simultaneously. On your go (any time during the Day):
+Players act simultaneously. On your go (any time during the Day), follow this loop:
 
-1. Roll to Move: roll 1d6; you have that many movement points for this move.
-2. Spend movement to move to adjacent hexes; each hex has a movement cost of 1, 2, or 3.
-3. If you enter a hex with a bug, you must stop and Fight it; any unspent movement is lost.
+1. Roll 1d6 for movement points.
+2. Spend those points moving to adjacent hexes (cost 1–3 each).
+   - If you run out without reaching a bug, roll again for movement.
+   - If you enter a bug’s hex, stop and fight; any unused movement is lost.
+3. Fight the bug until it’s defeated.
+4. Roll for movement again and keep hunting.
 
 You cannot move through a hex containing another player’s current fight. You may pass through other players otherwise.
 


### PR DESCRIPTION
## Summary
- clarify the real-time play loop with a numbered flow that cycles through rolling, moving, fighting, and rolling again
- note that unused movement is lost when entering a bug's hex

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b38624f4688332b2d06ad63566f016