### PR TITLE
Correct negative HP notation in Forward cards

### DIFF
--- a/forward/FORWARD CARDS - 8.30.25.csv
+++ b/forward/FORWARD CARDS - 8.30.25.csv
@@ -62,7 +62,7 @@ Cannot spend resolve",The reek gnaws at resolve; every breath remembers.
 25,Caesura,Home Villiage Termina,Back stairs holding breath,,EFFECT: None,Wood does not argue with careful feet.
 26,Pit,Home Villiage Termina,Infiltrate the Magistrate’s manor,,"CHALLENGE - Save on 3+
 Roll 1d6 until you have 3 saves or 3 fails.
-Each fail: -2 HP.
+Each fail: lose 2 HP.
 On 3 fails: move the Resolve/Dread marker down 1.","If you fail, turned villagers force a terrible choice."
 27,Hollow,Home Villiage Termina,Confront Ellard and his lackeys,,"FIGHT: 3 HP
 ----------
@@ -132,8 +132,8 @@ If 3 failures, move the Resolve/Dread marker down 1","Pay, talk, or vanish into 
 54,Snare,Bannered City Valthria,Intoxicating spices,,"EFFECT: 
 Cannot spend resolve",Scent blinds judgment; excess wears a smile.
 55,Caesura,Bannered City Valthria,Alleys braid and unbraid,,EFFECT: None,Corners practice misdirection for sport.
-56,Item,Bannered City Valthria,Moonleaf Brandy,,"USE: 
-Heal 7 HP, then lose -1d6 HP",Warm courage in a bottle; debts arrive later.
+56,Item,Bannered City Valthria,Moonleaf Brandy,,"USE:
+Heal 7 HP, then lose 1d6 HP",Warm courage in a bottle; debts arrive later.
 57,Caesura,Bannered City Valthria,Street vendor chorus,,EFFECT: None,Calls weave through you and keep going.
 58,Hollow,Bannered City Valthria,Assassin in the crowd,,"FIGHT: 
 3 HP


### PR DESCRIPTION
## Summary
- Fix Moonleaf Brandy item text to lose 1d6 HP instead of lose -1d6 HP
- Clarify challenge failure damage to "lose 2 HP" for consistency

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest` *(no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_68b38f5efee083328ef504cffa7d41bb