### PR TITLE
Replace home page with Reverie port + generative parameter drift

### DIFF
--- a/drift-new.html
+++ b/drift-new.html
@@ -1,0 +1,1325 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Peter Baumgartner — Drift (experimental)</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;700&display=swap" rel="stylesheet">
+    <style>
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+
+        :root {
+            --bg:           #0C0E18;
+            --viz-bg:       #080A14;
+            --header-bg:    #0A0C14;
+            --panel-bg:     rgba(26, 26, 26, 0.38);
+            --text:         #E0DCD4;
+            --text-dim:     #6B7080;
+            --text-muted:   #4A4E5A;
+            --midline:      #2E2E2E;
+            --bloom-blue:   #8AB4E8;
+            --bloom-gold:   #D4A854;
+            --bloom-indigo: #6A5ACD;
+            --bloom-purple: #9A6ACD;
+            --arc-immersion: #8AB4E8;
+            --arc-expanse:   #8AB4E8;
+            --arc-ascend:    #D4A854;
+            --arc-descend:   #6A5ACD;
+            --arc-lush:      #6AC4D4;
+            --arc-glow:      #D4946A;
+            --arc-muted:     #6B7080;
+            --cascade:       #D4A854;
+            --toggle-on:     #6AC4D4;
+        }
+
+        body {
+            background: var(--bg);
+            color: var(--text);
+            font-family: 'Outfit', sans-serif;
+            overflow: hidden;
+            height: 100vh;
+            cursor: default;
+            -webkit-font-smoothing: antialiased;
+        }
+
+        #vizCanvas {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100vw;
+            height: 100vh;
+            opacity: 0;
+            transition: opacity 1.5s ease-out;
+        }
+        #vizCanvas.active { opacity: 1; }
+
+        /* ── SLIDER STACK (bottom-left, front panel) ── */
+        .slider-stack {
+            position: fixed;
+            bottom: 30px;
+            left: 30px;
+            display: flex;
+            flex-direction: column;
+            gap: 10px;
+            z-index: 100;
+            opacity: 0;
+            transition: opacity 1.2s ease-out;
+        }
+        .slider-stack.loaded { opacity: 1; }
+
+        .slider-row {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            pointer-events: all;
+        }
+        .slider-label {
+            font-size: 9px;
+            letter-spacing: 0.15em;
+            text-transform: uppercase;
+            color: rgba(255,255,255,0.35);
+            width: 78px;
+            text-align: right;
+            flex-shrink: 0;
+        }
+        .param-slider {
+            width: 80px;
+            height: 2px;
+            -webkit-appearance: none;
+            appearance: none;
+            background: rgba(255,255,255,0.15);
+            outline: none;
+            cursor: pointer;
+            border-radius: 1px;
+        }
+        .param-slider::-webkit-slider-thumb {
+            -webkit-appearance: none;
+            width: 8px;
+            height: 8px;
+            background: rgba(255,255,255,0.5);
+            border-radius: 50%;
+            cursor: pointer;
+            transition: background 0.2s;
+        }
+        .param-slider::-webkit-slider-thumb:hover {
+            background: rgba(255,255,255,0.8);
+        }
+        .param-slider::-moz-range-thumb {
+            width: 8px;
+            height: 8px;
+            background: rgba(255,255,255,0.5);
+            border-radius: 50%;
+            cursor: pointer;
+            border: none;
+        }
+
+        .slider-value {
+            font-size: 9px;
+            letter-spacing: 0.05em;
+            color: rgba(255,255,255,0.40);
+            width: 56px;
+            text-align: left;
+            flex-shrink: 0;
+            font-variant-numeric: tabular-nums;
+        }
+
+        /* ── ADVANCED TOGGLE + PANEL ── */
+        .advanced-toggle {
+            font-size: 9px;
+            letter-spacing: 0.20em;
+            text-transform: uppercase;
+            color: rgba(255,255,255,0.40);
+            margin-top: 8px;
+            padding: 4px 0;
+            cursor: pointer;
+            user-select: none;
+            transition: color 0.3s;
+            background: none;
+            border: none;
+            font-family: inherit;
+            text-align: left;
+            width: fit-content;
+        }
+        .advanced-toggle:hover {
+            color: rgba(255,255,255,0.85);
+        }
+        .advanced-toggle .arrow {
+            display: inline-block;
+            margin-left: 4px;
+            transition: transform 0.3s;
+        }
+        .advanced-toggle.open .arrow {
+            transform: rotate(90deg);
+        }
+
+        .advanced-stack {
+            position: fixed;
+            bottom: 30px;
+            left: 280px;
+            display: flex;
+            flex-direction: column;
+            gap: 10px;
+            z-index: 100;
+            opacity: 0;
+            transform: translateX(-12px);
+            pointer-events: none;
+            transition: opacity 0.4s ease-out, transform 0.4s ease-out;
+        }
+        .advanced-stack.open {
+            opacity: 1;
+            transform: translateX(0);
+            pointer-events: all;
+        }
+        .advanced-stack .section-label {
+            font-size: 8px;
+            letter-spacing: 0.25em;
+            text-transform: uppercase;
+            color: rgba(255,255,255,0.25);
+            margin-top: 4px;
+            margin-bottom: -2px;
+        }
+        .advanced-stack .section-label:first-child {
+            margin-top: 0;
+        }
+
+        /* ── INFO OVERLAY ── */
+        .info-overlay {
+            position: fixed;
+            top: 0;
+            left: 0; right: 0;
+            bottom: 0;
+            padding: 30px;
+            pointer-events: none;
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-start;
+            z-index: 80;
+            opacity: 0;
+            transition: opacity 1.2s ease-out;
+        }
+        .info-overlay.loaded { opacity: 1; }
+
+        .info-left, .info-right {
+            font-size: 10px;
+            letter-spacing: 0.15em;
+            line-height: 1.8;
+            text-transform: uppercase;
+            text-shadow: 0 0 20px rgba(0,0,0,0.8);
+        }
+        .info-left strong, .info-right strong {
+            font-weight: 400;
+            opacity: 1;
+        }
+        .info-left a, .info-left span, .info-left br + * {
+            opacity: 0.5;
+        }
+        .info-right { text-align: right; }
+        .info-right span, .info-right strong { opacity: 0.7; }
+
+        .info-left a {
+            color: #fff;
+            text-decoration: none;
+            pointer-events: all;
+            transition: opacity 0.3s;
+        }
+        .info-left a:hover { opacity: 1; }
+        .info-right a {
+            color: #fff;
+            text-decoration: none;
+            pointer-events: all;
+            opacity: 0.5;
+            transition: opacity 0.3s;
+        }
+        .info-right a:hover { opacity: 1; }
+
+        .experimental-tag {
+            font-size: 8px;
+            letter-spacing: 0.30em;
+            color: rgba(212, 168, 84, 0.55);
+            margin-top: 6px;
+        }
+
+        /* ── START OVERLAY ── */
+        .overlay {
+            position: fixed;
+            inset: 0;
+            background: #000;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            z-index: 1000;
+            transition: opacity 1.5s;
+            cursor: pointer;
+        }
+        .overlay.hidden {
+            opacity: 0;
+            pointer-events: none;
+        }
+        .overlay-text {
+            font-size: 10px;
+            letter-spacing: 0.2em;
+            opacity: 0.5;
+            text-transform: uppercase;
+        }
+    </style>
+</head>
+<body>
+
+<canvas id="vizCanvas"></canvas>
+
+<div class="info-overlay" id="infoOverlay">
+    <div class="info-left">
+        <strong>Peter Baumgartner</strong><br>
+        37 / M / Mission Viejo<br>
+        <a href="https://www.linkedin.com/in/peter-baumgartner-b0094a49/" target="_blank">PM @ Microsoft</a><br>
+        <a href="https://open.spotify.com/artist/4T87J20L8uHSVkOuhP2oYX" target="_blank">music</a><br>
+        <a href="mailto:p.l.baumgartner@gmail.com">contact</a>
+        <div class="experimental-tag">DRIFT · EXPERIMENTAL</div>
+    </div>
+    <div class="info-right">
+        <strong id="elapsed">00:00</strong><br>
+        <span id="key">—</span> <span id="mode">—</span><br>
+        <span id="mood">—</span><br>
+        <strong id="active-voices">0</strong> ACTIVE<br>
+        <span id="voice-count">0</span> VOICES<br>
+        <a href="#" id="pauseBtn">pause</a> · <a href="#" id="restartBtn">restart</a>
+    </div>
+</div>
+
+<!-- Front panel sliders (mirror Drift plugin front knobs) -->
+<div class="slider-stack" id="sliderStack">
+    <div class="slider-row">
+        <span class="slider-label">In</span>
+        <input type="range" class="param-slider" data-param="inGain" min="0" max="100" value="80">
+        <span class="slider-value" data-param-value="inGain">0.0 dB</span>
+    </div>
+    <div class="slider-row">
+        <span class="slider-label">Immersion</span>
+        <input type="range" class="param-slider" data-param="immersion" min="0" max="100" value="30">
+        <span class="slider-value" data-param-value="immersion">30%</span>
+    </div>
+    <div class="slider-row">
+        <span class="slider-label">Distance</span>
+        <input type="range" class="param-slider" data-param="distance" min="0" max="100" value="50">
+        <span class="slider-value" data-param-value="distance">2.75x</span>
+    </div>
+    <div class="slider-row">
+        <span class="slider-label">Expanse</span>
+        <input type="range" class="param-slider" data-param="expanse" min="0" max="100" value="22">
+        <span class="slider-value" data-param-value="expanse">5.0 s</span>
+    </div>
+    <div class="slider-row">
+        <span class="slider-label">Feedback</span>
+        <input type="range" class="param-slider" data-param="feedback" min="0" max="100" value="0">
+        <span class="slider-value" data-param-value="feedback">0%</span>
+    </div>
+    <div class="slider-row">
+        <span class="slider-label">Mod Depth</span>
+        <input type="range" class="param-slider" data-param="modDepth" min="0" max="100" value="40">
+        <span class="slider-value" data-param-value="modDepth">40%</span>
+    </div>
+    <div class="slider-row">
+        <span class="slider-label">Glow</span>
+        <input type="range" class="param-slider" data-param="glow" min="0" max="100" value="10">
+        <span class="slider-value" data-param-value="glow">10%</span>
+    </div>
+    <div class="slider-row">
+        <span class="slider-label">Ascend</span>
+        <input type="range" class="param-slider" data-param="ascend" min="0" max="100" value="10">
+        <span class="slider-value" data-param-value="ascend">10%</span>
+    </div>
+    <div class="slider-row">
+        <span class="slider-label">Descend</span>
+        <input type="range" class="param-slider" data-param="descend" min="0" max="100" value="0">
+        <span class="slider-value" data-param-value="descend">0%</span>
+    </div>
+    <div class="slider-row">
+        <span class="slider-label">Drift</span>
+        <input type="range" class="param-slider" data-param="drift" min="0" max="100" value="10">
+        <span class="slider-value" data-param-value="drift">10%</span>
+    </div>
+    <div class="slider-row">
+        <span class="slider-label">Out</span>
+        <input type="range" class="param-slider" data-param="outGain" min="0" max="100" value="80">
+        <span class="slider-value" data-param-value="outGain">0.0 dB</span>
+    </div>
+
+    <button class="advanced-toggle" id="advancedToggle" type="button">
+        Advanced<span class="arrow">▸</span>
+    </button>
+</div>
+
+<!-- Advanced panel — everything not on Drift's front -->
+<div class="advanced-stack" id="advancedStack">
+    <div class="section-label">Reverb</div>
+    <div class="slider-row">
+        <span class="slider-label">Tone</span>
+        <input type="range" class="param-slider" data-param="tone" min="0" max="100" value="50">
+        <span class="slider-value" data-param-value="tone">0 dB</span>
+    </div>
+    <div class="slider-row">
+        <span class="slider-label">Shimmer</span>
+        <input type="range" class="param-slider" data-param="shimmer" min="0" max="100" value="25">
+        <span class="slider-value" data-param-value="shimmer">25%</span>
+    </div>
+    <div class="slider-row">
+        <span class="slider-label">Stereo Width</span>
+        <input type="range" class="param-slider" data-param="stereoWidth" min="0" max="100" value="50">
+        <span class="slider-value" data-param-value="stereoWidth">100%</span>
+    </div>
+    <div class="slider-row">
+        <span class="slider-label">Spatial</span>
+        <input type="range" class="param-slider" data-param="spatial" min="0" max="100" value="40">
+        <span class="slider-value" data-param-value="spatial">40%</span>
+    </div>
+    <div class="section-label">Voices</div>
+    <div class="slider-row">
+        <span class="slider-label">Melody</span>
+        <input type="range" class="param-slider" data-param="mVoiceVol" min="0" max="100" value="100">
+        <span class="slider-value" data-param-value="mVoiceVol">100%</span>
+    </div>
+    <div class="slider-row">
+        <span class="slider-label">Tintinnabuli</span>
+        <input type="range" class="param-slider" data-param="tVoiceVol" min="0" max="100" value="100">
+        <span class="slider-value" data-param-value="tVoiceVol">100%</span>
+    </div>
+    <div class="slider-row">
+        <span class="slider-label">Drone</span>
+        <input type="range" class="param-slider" data-param="droneVol" min="0" max="100" value="100">
+        <span class="slider-value" data-param-value="droneVol">100%</span>
+    </div>
+    <div class="slider-row">
+        <span class="slider-label">Bells</span>
+        <input type="range" class="param-slider" data-param="bellVol" min="0" max="100" value="100">
+        <span class="slider-value" data-param-value="bellVol">100%</span>
+    </div>
+    <div class="section-label">Atmosphere</div>
+    <div class="slider-row">
+        <span class="slider-label">Space</span>
+        <input type="range" class="param-slider" data-param="atmoSpace" min="0" max="100" value="70">
+        <span class="slider-value" data-param-value="atmoSpace">70%</span>
+    </div>
+    <div class="slider-row">
+        <span class="slider-label">Density</span>
+        <input type="range" class="param-slider" data-param="atmoDensity" min="0" max="100" value="55">
+        <span class="slider-value" data-param-value="atmoDensity">55%</span>
+    </div>
+    <div class="slider-row">
+        <span class="slider-label">Warmth</span>
+        <input type="range" class="param-slider" data-param="atmoWarmth" min="0" max="100" value="50">
+        <span class="slider-value" data-param-value="atmoWarmth">50%</span>
+    </div>
+    <div class="slider-row">
+        <span class="slider-label">Breath</span>
+        <input type="range" class="param-slider" data-param="atmoBreath" min="0" max="100" value="35">
+        <span class="slider-value" data-param-value="atmoBreath">35%</span>
+    </div>
+</div>
+
+<div class="overlay" id="overlay">
+    <div class="overlay-text">enter ⏎</div>
+</div>
+
+<script>
+// ═══════════════════════════════════════════════════════════════════════════════
+// Drift — experimental web port
+// Mirrors current Drift plugin parameter set (front + advanced).
+// Reuses tintinnabuli generative engine + spectral bloom visualization
+// from the home page (index.html). Background animation is intentionally
+// unchanged.
+// ═══════════════════════════════════════════════════════════════════════════════
+
+// ── SIMPLEX NOISE (2D) ──────────────────────────────────────────────────────
+const F2 = 0.3660254037844386, G2 = 0.21132486540518713;
+const grad2 = [[1,1],[-1,1],[1,-1],[-1,-1],[1,0],[-1,0],[0,1],[0,-1]];
+const perm = [151,160,137,91,90,15,131,13,201,95,96,53,194,233,7,225,140,36,103,30,69,142,8,99,37,240,21,10,23,190,6,148,247,120,234,75,0,26,197,62,94,252,219,203,117,35,11,32,57,177,33,88,237,149,56,87,174,20,125,136,171,168,68,175,74,165,71,134,139,48,27,166,77,146,158,231,83,111,229,122,60,211,133,230,220,105,92,41,55,46,245,40,244,102,143,54,65,25,63,161,1,216,80,73,209,76,132,187,208,89,18,169,200,196,135,130,116,188,159,86,164,100,109,198,173,186,3,64,52,217,226,250,124,123,5,202,38,147,118,126,255,82,85,212,207,206,59,227,47,16,58,17,182,189,28,42,223,183,170,213,119,248,152,2,44,154,163,70,221,153,101,155,167,43,172,9,129,22,39,253,19,98,108,110,79,113,224,232,178,185,112,104,218,246,97,228,251,34,242,193,238,210,144,12,191,179,162,241,81,51,145,235,249,14,239,107,49,192,214,31,181,199,106,157,184,84,204,176,115,121,50,45,127,4,150,254,138,236,205,93,222,114,67,29,24,72,243,141,128,195,78,66,215,61,156,180];
+const hp = i => perm[i & 255];
+
+function simplex2D(x, y) {
+    const s = (x + y) * F2;
+    const i = Math.floor(x + s), j = Math.floor(y + s);
+    const t = (i + j) * G2;
+    const x0 = x - (i - t), y0 = y - (j - t);
+    const i1 = x0 > y0 ? 1 : 0, j1 = x0 > y0 ? 0 : 1;
+    const x1 = x0 - i1 + G2, y1 = y0 - j1 + G2;
+    const x2 = x0 - 1 + 2 * G2, y2 = y0 - 1 + 2 * G2;
+    const gi0 = hp(i + hp(j)) % 8, gi1 = hp(i + i1 + hp(j + j1)) % 8, gi2 = hp(i + 1 + hp(j + 1)) % 8;
+    let t0 = 0.5 - x0*x0 - y0*y0, t1 = 0.5 - x1*x1 - y1*y1, t2 = 0.5 - x2*x2 - y2*y2;
+    const n0 = t0 < 0 ? 0 : (t0 *= t0, t0 * t0 * (grad2[gi0][0]*x0 + grad2[gi0][1]*y0));
+    const n1 = t1 < 0 ? 0 : (t1 *= t1, t1 * t1 * (grad2[gi1][0]*x1 + grad2[gi1][1]*y1));
+    const n2 = t2 < 0 ? 0 : (t2 *= t2, t2 * t2 * (grad2[gi2][0]*x2 + grad2[gi2][1]*y2));
+    return 70 * (n0 + n1 + n2);
+}
+
+function fbm2D(x, y, t, octaves = 3) {
+    let val = 0, amp = 1, freq = 1, maxAmp = 0;
+    for (let o = 0; o < octaves; o++) {
+        val += simplex2D(x * freq + t * 0.3, y * freq + t * 0.2) * amp;
+        maxAmp += amp; amp *= 0.5; freq *= 2;
+    }
+    return val / maxAmp;
+}
+
+// ── COLOR HELPERS ────────────────────────────────────────────────────────────
+function hexToRgb(hex) {
+    const n = parseInt(hex.replace('#',''), 16);
+    return [(n >> 16) & 255, (n >> 8) & 255, n & 255];
+}
+function lerpColor(c1, c2, t) {
+    return [c1[0]+(c2[0]-c1[0])*t, c1[1]+(c2[1]-c1[1])*t, c1[2]+(c2[2]-c1[2])*t];
+}
+function rgba(c, a) { return `rgba(${c[0]|0},${c[1]|0},${c[2]|0},${a})`; }
+const clamp01 = v => Math.max(0, Math.min(1, v));
+
+// ── PARAM STATE ──────────────────────────────────────────────────────────────
+// dB ↔ linear helpers. UI is 0..100; piecewise so that UI 80 = exactly 0 dB.
+//   UI  0 → -60 dB,  UI 80 → 0 dB,  UI 100 → +12 dB
+function uiToDb(ui) {
+    if (ui <= 0) return -Infinity;
+    return ui <= 80 ? (ui / 80) * 60 - 60 : ((ui - 80) / 20) * 12;
+}
+function dbToUi(db) {
+    if (db === -Infinity) return 0;
+    return db < 0 ? ((db + 60) / 60) * 80 : 80 + (db / 12) * 20;
+}
+function dbToLinear(db) { return db === -Infinity ? 0 : Math.pow(10, db / 20); }
+function fmtDb(db)      { return db === -Infinity ? '−∞ dB' : `${db.toFixed(1)} dB`; }
+
+const params = {
+    // Front panel (mirrors Drift plugin)
+    inGain:    { value: 0,    label: 'In',          fmt: v => fmtDb(v) },
+    immersion: { value: 0.30, label: 'Immersion',   fmt: v => `${Math.round(v*100)}%` },
+    distance:  { value: 2.75, label: 'Distance',    fmt: v => `${v.toFixed(2)}x` },
+    expanse:   { value: 5.0,  label: 'Expanse',     fmt: v => v < 10 ? `${v.toFixed(1)} s` : `${v.toFixed(0)} s` },
+    feedback:  { value: 0,    label: 'Feedback',    fmt: v => `${Math.round(v*100)}%` },
+    modDepth:  { value: 0.40, label: 'Mod Depth',   fmt: v => `${Math.round(v*100)}%` },
+    glow:      { value: 0.10, label: 'Glow',        fmt: v => `${Math.round(v*100)}%` },
+    ascend:    { value: 0.10, label: 'Ascend',      fmt: v => `${Math.round(v*100)}%` },
+    descend:   { value: 0,    label: 'Descend',     fmt: v => `${Math.round(v*100)}%` },
+    drift:     { value: 0.10, label: 'Drift',       fmt: v => `${Math.round(v*100)}%` },
+    outGain:   { value: 0,    label: 'Out',         fmt: v => fmtDb(v) },
+    // Advanced
+    tone:        { value: 0,    label: 'Tone',         fmt: v => `${(v*6).toFixed(1)} dB` },
+    shimmer:     { value: 0.25, label: 'Shimmer',      fmt: v => `${Math.round(v*100)}%` },
+    stereoWidth: { value: 1.0,  label: 'Stereo Width', fmt: v => `${v.toFixed(2)}x` },
+    spatial:     { value: 0.40, label: 'Spatial',      fmt: v => `${Math.round(v*100)}%` },
+    mVoiceVol:   { value: 1.0,  label: 'Melody',       fmt: v => `${Math.round(v*100)}%` },
+    tVoiceVol:   { value: 1.0,  label: 'Tintinnabuli', fmt: v => `${Math.round(v*100)}%` },
+    droneVol:    { value: 1.0,  label: 'Drone',        fmt: v => `${Math.round(v*100)}%` },
+    bellVol:     { value: 1.0,  label: 'Bells',        fmt: v => `${Math.round(v*100)}%` },
+    atmoSpace:   { value: 0.70, label: 'Space',        fmt: v => `${Math.round(v*100)}%` },
+    atmoDensity: { value: 0.55, label: 'Density',      fmt: v => `${Math.round(v*100)}%` },
+    atmoWarmth:  { value: 0.50, label: 'Warmth',       fmt: v => `${Math.round(v*100)}%` },
+    atmoBreath:  { value: 0.35, label: 'Breath',       fmt: v => `${Math.round(v*100)}%` },
+};
+
+// Convert slider 0–100 to param value (depends on which param)
+function sliderToValue(name, ui) {
+    const u = ui / 100;
+    switch (name) {
+        case 'inGain':
+        case 'outGain':   return uiToDb(ui);
+        case 'distance':  return 0.5 + u * 4.5;            // 0.5–5.0
+        case 'expanse':   return 0.1 + u * 59.9;           // 0.1–60s
+        case 'tone':      return (u - 0.5) * 2;            // -1..+1
+        case 'stereoWidth': return u * 2;                  // 0–2
+        default:          return u;                        // 0–1 normalized
+    }
+}
+function valueToSlider(name, v) {
+    switch (name) {
+        case 'inGain':
+        case 'outGain':   return Math.max(0, Math.min(100, dbToUi(v)));
+        case 'distance':  return ((v - 0.5) / 4.5) * 100;
+        case 'expanse':   return ((v - 0.1) / 59.9) * 100;
+        case 'tone':      return (v / 2 + 0.5) * 100;
+        case 'stereoWidth': return (v / 2) * 100;
+        default:          return v * 100;
+    }
+}
+
+// ── TINTINNABULI GENERATIVE ENGINE (unchanged from index.html) ──────────────
+const NOTE_NAMES = ['C','C#','D','D#','E','F','F#','G','G#','A','A#','B'];
+const MODES = {
+    aeolian:     { intervals: [0,2,3,5,7,8,10],  name:'Aeolian',     character:'sorrowful' },
+    dorian:      { intervals: [0,2,3,5,7,9,10],  name:'Dorian',      character:'contemplative' },
+    phrygian:    { intervals: [0,1,3,5,7,8,10],  name:'Phrygian',    character:'mournful' },
+    lydian:      { intervals: [0,2,4,6,7,9,11],  name:'Lydian',      character:'luminous' },
+    mixolydian:  { intervals: [0,2,4,5,7,9,10],  name:'Mixolydian',  character:'pastoral' },
+    ionian:      { intervals: [0,2,4,5,7,9,11],  name:'Ionian',      character:'pure' },
+};
+const TRIADS = { major:[0,4,7], minor:[0,3,7] };
+
+let audioCtx, masterGain, inputGain, compressor, voiceBus;
+let analyserNode, reverbWorkletNode = null;
+let sacredRoot = 0, sacredMode = 'aeolian', sacredTriad = 'minor';
+let lastMelodyNote = 60, melodyDirection = 1;
+let mVoice = null, tVoice = null, droneVoice = null, bellVoice = null;
+let driftRunning = false, driftPaused = false;
+let startTime = 0, pausedTime = 0, totalPausedDuration = 0, activeNotes = 0;
+let tintAtmosphere = { space:0.7, density:0.55, warmth:0.5, breath:0.35 };
+let tintAtmosphereTargets = { ...tintAtmosphere };
+let atmosphereInterval = null, atmosphereChangeTimeout = null, tonalityChangeTimeout = null;
+
+const rand = (a,b) => Math.random()*(b-a)+a;
+const randInt = (a,b) => Math.floor(rand(a,b+1));
+const pick = arr => arr[Math.floor(Math.random()*arr.length)];
+const clampa = (v,a,b) => Math.max(a,Math.min(b,v));
+const midiToFreq = m => 440*Math.pow(2,(m-69)/12);
+const midiToNoteName = m => NOTE_NAMES[m%12]+Math.floor(m/12-1);
+
+function getSacredScale() {
+    const iv = MODES[sacredMode].intervals, notes = [];
+    for (let o=2; o<=7; o++) for (const i of iv) { const m=sacredRoot+i+o*12; if(m>=36&&m<=96) notes.push(m); }
+    return notes;
+}
+function getSacredTriad() {
+    const t = TRIADS[sacredTriad], notes = [];
+    for (let o=2; o<=7; o++) for (const i of t) { const m=sacredRoot+i+o*12; if(m>=36&&m<=96) notes.push(m); }
+    return notes;
+}
+function getScaleInRange(lo,hi) { return getSacredScale().filter(n=>n>=lo&&n<=hi); }
+function getTriadInRange(lo,hi) { return getSacredTriad().filter(n=>n>=lo&&n<=hi); }
+
+function getNextStepwiseNote(cur, range) {
+    const sc = getScaleInRange(range[0],range[1]);
+    if (!sc.length) return null;
+    let idx = sc.indexOf(cur);
+    if (idx===-1) { const d=sc.map(n=>Math.abs(n-cur)); idx=d.indexOf(Math.min(...d)); }
+    let next = idx + melodyDirection;
+    if (next>=sc.length||next<0) { melodyDirection*=-1; next=idx+melodyDirection; }
+    if (Math.random()<0.12) melodyDirection*=-1;
+    if (Math.random()<0.08) { next=idx+melodyDirection*2; next=clampa(next,0,sc.length-1); }
+    return sc[next];
+}
+function getTintinnabuliNote(mNote, position) {
+    const tn = getSacredTriad();
+    if (position==='superior') { const a=tn.filter(n=>n>=mNote); return a.length?a[0]:tn[tn.length-1]; }
+    const b=tn.filter(n=>n<=mNote); return b.length?b[b.length-1]:tn[0];
+}
+
+class SacredVoice {
+    constructor(ctx, output, config) {
+        this.ctx=ctx; this.config=config; this.isVoicePlaying=false;
+        this.timeout=null; this.activeOscs=[];
+        this.filter=ctx.createBiquadFilter(); this.filter.type='lowpass';
+        this.filter.frequency.value=config.brightness||2000; this.filter.Q.value=0.5;
+        this.panner=ctx.createStereoPanner(); this.panner.pan.value=config.pan||0;
+        this.gain=ctx.createGain(); this.gain.gain.value=config.volume||0.2;
+        this.userVol = 1.0; // multiplicative trim from advanced panel
+        this.baseVolume = config.volume || 0.2;
+        this.filter.connect(this.panner); this.panner.connect(this.gain); this.gain.connect(output);
+        this.panDriftTimeout=null;
+    }
+    setUserVolume(v) {
+        this.userVol = v;
+        if (this.gain) this.gain.gain.setTargetAtTime(this.baseVolume * v, this.ctx.currentTime, 0.05);
+    }
+    start() { this.isVoicePlaying=true; this.scheduleNext(true); this.startPanDrift(); }
+    stop() {
+        this.isVoicePlaying=false;
+        if(this.timeout){clearTimeout(this.timeout);this.timeout=null;}
+        if(this.panDriftTimeout){clearTimeout(this.panDriftTimeout);this.panDriftTimeout=null;}
+        this.activeOscs.forEach(n=>{try{n.env.gain.setTargetAtTime(0,this.ctx.currentTime,0.5);setTimeout(()=>{try{n.osc.stop();}catch(e){}try{n.osc2?.stop();}catch(e){}},1000);}catch(e){}});
+        this.activeOscs=[];
+    }
+    scheduleNext(immediate=false) {
+        if(!this.isVoicePlaying)return;
+        if(immediate) this.playNote();
+        const base=this.config.interval||5000;
+        const dm=1.8-tintAtmosphere.density*0.8;
+        const interval=base*dm*rand(0.7,1.3);
+        this.timeout=setTimeout(()=>{
+            if(!this.isVoicePlaying)return;
+            const sc=Math.max(0,0.6-tintAtmosphere.density*0.8);
+            if(Math.random()<sc){this.scheduleNext();return;}
+            this.playNote(); this.scheduleNext();
+        },interval);
+    }
+    playNote(){}
+    createBellTone(freq, velocity=0.5) {
+        const now=this.ctx.currentTime;
+        const osc=this.ctx.createOscillator(); osc.type='sine'; osc.frequency.value=freq; osc.detune.value=rand(-4,4);
+        const osc2=this.ctx.createOscillator(); osc2.type='sine'; osc2.frequency.value=freq*2; osc2.detune.value=rand(-6,6);
+        const env=this.ctx.createGain(); env.gain.value=0;
+        const att=this.config.bellLike?0.008:(this.config.attack||0.6);
+        const dec=(this.config.decay||5)*(0.6+tintAtmosphere.warmth*0.6);
+        const vol=velocity*0.8;
+        env.gain.setValueAtTime(0,now);
+        env.gain.linearRampToValueAtTime(vol,now+att);
+        env.gain.exponentialRampToValueAtTime(0.001,now+att+dec);
+        const env2=this.ctx.createGain(); env2.gain.value=0;
+        env2.gain.setValueAtTime(0,now);
+        env2.gain.linearRampToValueAtTime(vol*0.12,now+att);
+        env2.gain.exponentialRampToValueAtTime(0.001,now+att+dec*0.6);
+        osc.connect(env); osc2.connect(env2); env.connect(this.filter); env2.connect(this.filter);
+        osc.start(now); osc2.start(now);
+        const obj={osc,osc2,env,env2}; this.activeOscs.push(obj);
+        const stop=(att+dec+1)*1000;
+        setTimeout(()=>{try{osc.stop();osc2.stop();}catch(e){}this.activeOscs=this.activeOscs.filter(n=>n!==obj);},stop);
+        activeNotes++; setTimeout(()=>{activeNotes=Math.max(0,activeNotes-1);},stop);
+    }
+    startPanDrift() {
+        const drift=()=>{if(!this.isVoicePlaying)return;
+            const np=clampa(this.panner.pan.value+rand(-0.4,0.4),-0.85,0.85);
+            const dt=rand(12,30); this.panner.pan.linearRampToValueAtTime(np,this.ctx.currentTime+dt);
+            this.panDriftTimeout=setTimeout(drift,dt*1000+rand(5000,15000));
+        }; drift();
+    }
+}
+
+class MelodicVoice extends SacredVoice {
+    constructor(ctx,out){super(ctx,out,{name:'M-voice',volume:0.32,brightness:2800,pan:-0.25,interval:4000,attack:0.5,decay:6,range:[48,72]});}
+    playNote(){
+        const n=getNextStepwiseNote(lastMelodyNote,this.config.range); if(!n)return;
+        lastMelodyNote=n; this.createBellTone(midiToFreq(n),rand(0.45,0.7));
+    }
+}
+class TintinnabuliVoice extends SacredVoice {
+    constructor(ctx,out){super(ctx,out,{name:'T-voice',volume:0.26,brightness:3200,pan:0.25,interval:5000,attack:0.3,decay:8,bellLike:true,range:[52,84]});this.position='superior';}
+    playNote(){
+        if(Math.random()<0.25) this.position=this.position==='superior'?'inferior':'superior';
+        let n=getTintinnabuliNote(lastMelodyNote,this.position);
+        const r=this.config.range; while(n<r[0])n+=12; while(n>r[1])n-=12;
+        this.createBellTone(midiToFreq(n),rand(0.35,0.55));
+    }
+}
+class DroneVoice extends SacredVoice {
+    constructor(ctx,out){super(ctx,out,{name:'Drone',volume:0.22,brightness:600,pan:0,interval:15000,attack:3,decay:18,range:[36,48]});}
+    playNote(){
+        const root=sacredRoot+36, fifth=root+7;
+        const n=Math.random()<0.75?root:fifth;
+        this.createBellTone(midiToFreq(n),rand(0.35,0.55));
+    }
+}
+class BellVoice extends SacredVoice {
+    constructor(ctx,out){super(ctx,out,{name:'Bells',volume:0.18,brightness:4500,pan:0,interval:18000,attack:0.008,decay:10,bellLike:true,range:[72,88]});}
+    playNote(){
+        const t=getTriadInRange(this.config.range[0],this.config.range[1]);
+        if(!t.length)return; this.createBellTone(midiToFreq(pick(t)),rand(0.25,0.45));
+    }
+}
+
+function startTintAtmosphere() {
+    Object.keys(tintAtmosphere).forEach(k=>{tintAtmosphereTargets[k]=tintAtmosphere[k];});
+    atmosphereInterval=setInterval(()=>{
+        Object.keys(tintAtmosphere).forEach(k=>{tintAtmosphere[k]+=(tintAtmosphereTargets[k]-tintAtmosphere[k])*0.012;});
+        applyTintAtmosphere();
+    },50);
+    scheduleTintAtmosphereChange();
+}
+function stopTintAtmosphere() {
+    if(atmosphereInterval){clearInterval(atmosphereInterval);atmosphereInterval=null;}
+    if(atmosphereChangeTimeout){clearTimeout(atmosphereChangeTimeout);atmosphereChangeTimeout=null;}
+}
+function scheduleTintAtmosphereChange() {
+    if(!driftRunning||driftPaused)return;
+    atmosphereChangeTimeout=setTimeout(()=>{
+        if(!driftRunning||driftPaused)return;
+        const ps=Object.keys(tintAtmosphere); const nc=Math.random()<0.4?2:1;
+        for(let i=0;i<nc;i++){
+            const p=pick(ps);
+            tintAtmosphereTargets[p]=Math.random()<0.35?(Math.random()<0.5?rand(0.12,0.3):rand(0.7,0.9)):clampa(tintAtmosphereTargets[p]+rand(-0.35,0.35),0.1,0.9);
+        }
+        scheduleTintAtmosphereChange();
+    },rand(15000,40000));
+}
+function applyTintAtmosphere() {
+    if(!masterGain||!audioCtx)return; const now=audioCtx.currentTime;
+    const wm=0.6+tintAtmosphere.warmth*0.8;
+    if(mVoice) mVoice.filter.frequency.setTargetAtTime(1800*wm,now,3);
+    if(tVoice) tVoice.filter.frequency.setTargetAtTime(2200*wm,now,3);
+    if(droneVoice) droneVoice.filter.frequency.setTargetAtTime(400*wm,now,3);
+    if(bellVoice) bellVoice.filter.frequency.setTargetAtTime(3500*wm,now,3);
+}
+
+function scheduleTonalityChange() {
+    if(!driftRunning||driftPaused)return;
+    tonalityChangeTimeout=setTimeout(()=>{
+        if(!driftRunning||driftPaused)return;
+        if(Math.random()<0.7){
+            sacredMode=pick(Object.keys(MODES));
+            sacredTriad=['aeolian','dorian','phrygian'].includes(sacredMode)?'minor':'major';
+        } else {
+            const mv=Math.random()<0.5?7:5, dir=Math.random()<0.5?1:-1;
+            sacredRoot=(sacredRoot+mv*dir+12)%12; lastMelodyNote=sacredRoot+60;
+        }
+        scheduleTonalityChange();
+    },rand(120000,360000));
+}
+
+// ── Apply params to audio (worklet + gain nodes + voices + atmosphere) ──────
+function applyParamsToAudio() {
+    if (!audioCtx) return;
+    const now = audioCtx.currentTime;
+    // IN / OUT gain (dB)
+    if (inputGain)  inputGain.gain.setTargetAtTime(dbToLinear(params.inGain.value),  now, 0.02);
+    if (masterGain) masterGain.gain.setTargetAtTime(dbToLinear(params.outGain.value), now, 0.02);
+    // Worklet params
+    if (reverbWorkletNode) {
+        const p = reverbWorkletNode.parameters;
+        p.get('mix').setValueAtTime(params.immersion.value, now);
+        p.get('distance').setValueAtTime(params.distance.value, now);
+        p.get('dimension').setValueAtTime(params.expanse.value, now);
+        p.get('feedback').setValueAtTime(params.feedback.value, now);
+        p.get('modDepth').setValueAtTime(params.modDepth.value, now);
+        p.get('warmth').setValueAtTime(params.glow.value, now);
+        p.get('octUp').setValueAtTime(params.ascend.value, now);
+        p.get('octDown').setValueAtTime(params.descend.value, now);
+        p.get('drift').setValueAtTime(params.drift.value, now);
+        p.get('tone').setValueAtTime(params.tone.value, now);
+        p.get('shimmerLevel').setValueAtTime(params.shimmer.value, now);
+        p.get('stereoWidth').setValueAtTime(params.stereoWidth.value, now);
+        p.get('spatial').setValueAtTime(params.spatial.value, now);
+    }
+    // Voice user volumes
+    if (mVoice) mVoice.setUserVolume(params.mVoiceVol.value);
+    if (tVoice) tVoice.setUserVolume(params.tVoiceVol.value);
+    if (droneVoice) droneVoice.setUserVolume(params.droneVol.value);
+    if (bellVoice) bellVoice.setUserVolume(params.bellVol.value);
+    // Atmosphere overrides — set targets so the smoothing loop converges to them
+    tintAtmosphereTargets.space   = params.atmoSpace.value;
+    tintAtmosphereTargets.density = params.atmoDensity.value;
+    tintAtmosphereTargets.warmth  = params.atmoWarmth.value;
+    tintAtmosphereTargets.breath  = params.atmoBreath.value;
+}
+
+async function initAudio() {
+    audioCtx = new (window.AudioContext||window.webkitAudioContext)();
+    analyserNode = audioCtx.createAnalyser();
+    analyserNode.fftSize = 256; analyserNode.smoothingTimeConstant = 0.85;
+    inputGain  = audioCtx.createGain(); inputGain.gain.value  = dbToLinear(params.inGain.value);
+    masterGain = audioCtx.createGain(); masterGain.gain.value = dbToLinear(params.outGain.value);
+    compressor = audioCtx.createDynamicsCompressor();
+    compressor.threshold.value = -24; compressor.knee.value = 30;
+    compressor.ratio.value = 6; compressor.attack.value = 0.005; compressor.release.value = 0.3;
+    const hpF = audioCtx.createBiquadFilter();
+    hpF.type = "highpass"; hpF.frequency.value = 20; hpF.Q.value = 0.7;
+
+    // Load updated AudioWorklet (drift-reverb)
+    await audioCtx.audioWorklet.addModule("drift-worklet-new.js");
+    reverbWorkletNode = new AudioWorkletNode(audioCtx, "drift-reverb", {
+        numberOfInputs: 1, numberOfOutputs: 1, outputChannelCount: [2],
+    });
+
+    // Voice bus → IN gain → worklet → OUT gain → compressor → HPF → analyser → output
+    voiceBus = audioCtx.createGain(); voiceBus.gain.value = 1;
+    voiceBus.connect(inputGain);
+    inputGain.connect(reverbWorkletNode);
+    reverbWorkletNode.connect(masterGain);
+    masterGain.connect(compressor);
+    compressor.connect(hpF);
+    hpF.connect(analyserNode);
+    analyserNode.connect(audioCtx.destination);
+
+    mVoice = new MelodicVoice(audioCtx, voiceBus);
+    tVoice = new TintinnabuliVoice(audioCtx, voiceBus);
+    droneVoice = new DroneVoice(audioCtx, voiceBus);
+    bellVoice = new BellVoice(audioCtx, voiceBus);
+
+    sacredRoot = randInt(0, 11);
+    sacredMode = pick(Object.keys(MODES));
+    sacredTriad = ["aeolian","dorian","phrygian"].includes(sacredMode) ? "minor" : "major";
+    lastMelodyNote = sacredRoot + 60;
+    Object.keys(tintAtmosphere).forEach(k => { const v = rand(0.25, 0.75); tintAtmosphere[k] = v; tintAtmosphereTargets[k] = v; });
+    applyParamsToAudio();
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SPECTRAL BLOOM VISUALIZATION (unchanged from index.html — wired to new params)
+// ─────────────────────────────────────────────────────────────────────────────
+
+const BLOOM_RES = 200;
+let upperBloom = new Float32Array(BLOOM_RES);
+let lowerBloom = new Float32Array(BLOOM_RES);
+let smoothedPeak = 0;
+let noisePhase = 0;
+let animPhase = 0;
+let descendThrob = 0;
+let cascadeBrightness = 0;
+let vizCanvas, vizCtx;
+let vizW, vizH;
+let cascadeActive = false, fxActive = false;
+
+let noiseFrames = [];
+let noiseFrameIdx = 0;
+let vblankCount = 0;
+
+function initFilmGrain() {
+    for (let f = 0; f < 4; f++) {
+        const c = document.createElement('canvas');
+        c.width = 550; c.height = 250;
+        const cx = c.getContext('2d');
+        const img = cx.createImageData(550, 250);
+        const d = img.data;
+        for (let i = 0; i < d.length; i += 4) {
+            const r = (Math.random() + Math.random() + Math.random()) / 3;
+            const v = (r * 255) | 0;
+            const a = 4 + (Math.random() * 6) | 0;
+            d[i] = v; d[i+1] = v; d[i+2] = v; d[i+3] = a;
+        }
+        cx.putImageData(img, 0, 0);
+        noiseFrames.push(c);
+    }
+}
+
+function getAudioPeak() {
+    if (!analyserNode) return 0;
+    const data = new Uint8Array(analyserNode.frequencyBinCount);
+    analyserNode.getByteTimeDomainData(data);
+    let peak = 0;
+    for (let i = 0; i < data.length; i++) peak = Math.max(peak, Math.abs(data[i] - 128) / 128);
+    return peak;
+}
+
+function updateBloomShapes() {
+    const mix = params.immersion.value;
+    const octUp = params.ascend.value;
+    const octDown = params.descend.value;
+    const decay = params.expanse.value;
+    const modD = params.modDepth.value;
+    // tone here is used only for visual tinting; map worklet -1..+1 to UI 0..1
+    const tone = params.tone.value * 0.5 + 0.5;
+
+    const currentPeak = clampa(getAudioPeak() * 3, 0, 1);
+    smoothedPeak += (currentPeak > smoothedPeak ? 0.5 : 0.06) * (currentPeak - smoothedPeak);
+
+    const cascadeTarget = cascadeActive ? 1 : 0;
+    cascadeBrightness += (cascadeTarget - cascadeBrightness) * 0.05;
+    animPhase += 0.011;
+    descendThrob += 0.004;
+    noisePhase += cascadeActive ? 0.003 : 0.025;
+
+    vblankCount++;
+    if (vblankCount >= 6) { noiseFrameIdx = (noiseFrameIdx + 1) % 4; vblankCount = 0; }
+
+    const idleBase = 0.13, reactivity = 1.58;
+    const audioLevel = idleBase + smoothedPeak * reactivity;
+    const mixScale = 0.9 + mix * 0.63;
+    const upperParam = 0.35 + octUp * 0.68;
+    const lowerParam = 0.35 + octDown * 0.68;
+
+    const decayNorm = clampa((decay - 0.1) / 59.9, 0, 1);
+    const baseSigma = 0.28 + decayNorm * 0.30;
+    let upperSigma = baseSigma * (1 - octUp * 0.3);
+    upperSigma = Math.max(0.12, upperSigma);
+    const lowerSigma = baseSigma * (1 + octDown * 0.4);
+    const gaussianCenter = 0.5;
+    const fbmOctaves = 3 + Math.floor(modD * 3);
+    const breathAmp = 0.4 + modD * 0.75;
+    const cascadeBoost = 1 + cascadeBrightness * 0.8;
+
+    for (let i = 0; i < BLOOM_RES; i++) {
+        const t = i / (BLOOM_RES - 1);
+        const tc = t - gaussianCenter;
+        const upperEnv = Math.exp(-(tc*tc) / (2 * upperSigma * upperSigma));
+        const lowerEnv = Math.exp(-(tc*tc) / (2 * lowerSigma * lowerSigma));
+        const nx = t * 3;
+        const nv1 = fbm2D(nx, 0, noisePhase, fbmOctaves) * 0.5 + 0.5;
+        const nv2 = fbm2D(nx + 10, 5, noisePhase * 0.8, fbmOctaves) * 0.5 + 0.5;
+        const breath = Math.sin(animPhase * 2.75 + t * 5.5) * breathAmp * 0.23;
+        upperBloom[i] = clampa((audioLevel + breath) * mixScale * upperParam * upperEnv * nv1 * cascadeBoost, 0, 1);
+        lowerBloom[i] = clampa((audioLevel * 0.8 + breath * 0.7) * mixScale * lowerParam * lowerEnv * nv2 * cascadeBoost, 0, 1);
+    }
+
+    if (octDown > 0.001) {
+        const throbMod = 1 + Math.sin(descendThrob) * octDown * 0.25;
+        for (let i = 0; i < BLOOM_RES; i++) lowerBloom[i] = clampa(lowerBloom[i] * throbMod, 0, 1);
+    }
+}
+
+function paintSpectralBloom() {
+    const g = vizCtx;
+    g.clearRect(0, 0, vizW, vizH);
+
+    const vx = 0;
+    const vw = vizW;
+    const vh = vizH * 0.6;
+    const vy = (vizH - vh) / 2;
+    const midY = vy + vh * 0.50;
+    const maxBloomH = vh * 0.47;
+
+    const mix = params.immersion.value;
+    const warmth = params.glow.value;
+    const tone = params.tone.value * 0.5 + 0.5;
+    const octUp = params.ascend.value;
+    const octDown = params.descend.value;
+
+    const glowIntensity = clampa(warmth * warmth * warmth * 4, 0, 1);
+    const sizzle = clampa((warmth - 0.75) * 4, 0, 1);
+    const glowSuppress = 1 - glowIntensity * 0.85;
+
+    const amberTint = [212,148,106], hotAmber = [232,130,58], scorchOrange = [240,112,26], blazeHot = [255,96,16];
+    const glowCol = lerpColor(lerpColor(amberTint, lerpColor(hotAmber, scorchOrange, glowIntensity), glowIntensity), blazeHot, sizzle * 0.5);
+    const darkAmber = [26,14,8];
+    const vizBgBase = hexToRgb('#080A14');
+    const vizBgCol = lerpColor(vizBgBase, darkAmber, glowIntensity * 0.9 + sizzle * 0.1);
+
+    const bloomBlue = hexToRgb('#8AB4E8'), bloomGold = hexToRgb('#D4A854');
+    const bloomIndigo = hexToRgb('#6A5ACD'), bloomPurple = hexToRgb('#9A6ACD');
+
+    g.fillStyle = rgba(vizBgCol, 1);
+    g.fillRect(0, 0, vizW, vizH);
+
+    const midAlpha = 0.10 + mix*0.12 + cascadeBrightness*0.08 + glowIntensity*0.15 + sizzle*0.20;
+    const midCol = lerpColor([46,46,46], glowCol, glowIntensity * 0.7);
+    g.strokeStyle = rgba(midCol, midAlpha);
+    g.lineWidth = 1;
+    g.beginPath();
+    g.moveTo(vx + 10, midY);
+    g.lineTo(vx + vw - 10, midY);
+    g.stroke();
+
+    let upperBaseCol = lerpColor(bloomBlue, glowCol, glowIntensity * 0.75);
+    let upperPeakCol = lerpColor(upperBaseCol, lerpColor(bloomGold, glowCol, glowIntensity*0.5), 0.3 + tone*0.5);
+
+    const ascWhiteGold = [255,244,208], ascBrightGold = [255,232,160];
+    upperBaseCol = lerpColor(upperBaseCol, ascBrightGold, octUp * 0.4 * glowSuppress);
+    upperPeakCol = lerpColor(upperPeakCol, ascWhiteGold, octUp * 0.75 * glowSuppress);
+
+    const descDeepViolet = [74,32,176], descRichPurple = [112,48,208];
+    let lowerBaseCol = lerpColor(lerpColor(bloomIndigo, glowCol, glowIntensity*0.6), descDeepViolet, octDown*0.5*glowSuppress);
+    let lowerPeakCol = lerpColor(lerpColor(lowerBaseCol, lerpColor(bloomPurple, glowCol, glowIntensity*0.4), 0.3+tone*0.3), descRichPurple, octDown*0.4*glowSuppress);
+
+    function drawBloom(bloom, dir, maxH, baseCol, peakCol, alphaBase, alphaPeak) {
+        const grad = g.createLinearGradient(vx + vw/2, midY, vx + vw/2, midY + dir * maxH);
+        grad.addColorStop(0, rgba(baseCol, alphaBase));
+        grad.addColorStop(0.4, rgba(bloomPurple.map((c,i)=>c+(glowCol[i]-c)*glowIntensity*0.5), 0.4 + glowIntensity*0.15));
+        grad.addColorStop(1, rgba(peakCol, alphaPeak));
+        g.fillStyle = grad;
+        g.beginPath();
+        g.moveTo(vx, midY);
+        for (let i = 0; i < BLOOM_RES; i++) {
+            const px = vx + (i / (BLOOM_RES-1)) * vw;
+            g.lineTo(px, midY + dir * bloom[i] * maxH);
+        }
+        g.lineTo(vx + vw, midY);
+        g.closePath();
+        g.fill();
+
+        g.fillStyle = rgba(peakCol, 0.06 + cascadeBrightness*0.04 + (dir < 0 ? octUp*0.10 : 0));
+        g.beginPath();
+        g.moveTo(vx, midY);
+        for (let i = 0; i < BLOOM_RES; i++) {
+            const px = vx + (i / (BLOOM_RES-1)) * vw;
+            g.lineTo(px, midY + dir * bloom[i] * maxH * 1.2);
+        }
+        g.lineTo(vx + vw, midY);
+        g.closePath();
+        g.fill();
+
+        const edgeA = dir < 0 ? (0.20 + octUp*0.20 + cascadeBrightness*0.15) : (0.15 + octDown*0.15);
+        g.strokeStyle = rgba(peakCol, edgeA);
+        g.lineWidth = 1.5 + (dir < 0 ? octUp : octDown) * 1;
+        g.beginPath();
+        for (let i = 0; i < BLOOM_RES; i++) {
+            const px = vx + (i / (BLOOM_RES-1)) * vw;
+            if (i === 0) g.moveTo(px, midY + dir * bloom[i] * maxH);
+            else g.lineTo(px, midY + dir * bloom[i] * maxH);
+        }
+        g.stroke();
+    }
+
+    function drawShells(bloom, dir, maxH, numShells, octAmt, innerCol, outerCol, deepCol) {
+        if (octAmt < 0.02) return;
+        for (let shell = numShells; shell >= 1; shell--) {
+            const expand = 1 + shell * 0.24 * octAmt;
+            let shellAlpha = (octAmt * octAmt) * 0.18 / (shell * 0.7);
+            shellAlpha = Math.min(shellAlpha, 0.35);
+            shellAlpha *= (1 - glowIntensity * 0.7);
+            const frac = (shell - 1) / (numShells - 1);
+            const shellCol = lerpColor(lerpColor(innerCol, outerCol, frac * 0.6), deepCol || outerCol, frac * 0.3);
+            g.fillStyle = rgba(shellCol, shellAlpha);
+            g.beginPath();
+            g.moveTo(vx, midY);
+            for (let i = 0; i < BLOOM_RES; i++) {
+                const px = vx + (i / (BLOOM_RES-1)) * vw;
+                const h = bloom[i] * maxH * (dir < 0 ? 1 : 0.8) * expand;
+                g.lineTo(px, midY + dir * h);
+            }
+            g.lineTo(vx + vw, midY);
+            g.closePath();
+            g.fill();
+        }
+    }
+
+    drawShells(upperBloom, -1, maxBloomH, 7, octUp, [255,244,208], [255,224,144], [255,255,255]);
+    drawShells(lowerBloom, 1, maxBloomH, 7, octDown, [106,58,224], [58,24,128], [42,16,96]);
+
+    drawBloom(upperBloom, -1, maxBloomH, upperBaseCol, upperPeakCol,
+        0.55 + octUp*0.10, 0.75 + cascadeBrightness*0.2 + octUp*0.15);
+    drawBloom(lowerBloom, 1, maxBloomH * 0.8, lowerBaseCol, lowerPeakCol, 0.45, 0.30);
+
+    if (glowIntensity > 0.01) {
+        const sunCore = [255,248,224];
+        for (let shell = 2; shell >= 1; shell--) {
+            const expand = 1 + shell * 0.12 * glowIntensity;
+            let sa = (glowIntensity * 0.30 + sizzle * 0.25) / shell;
+            sa = Math.min(sa, 0.55);
+            const sCol = lerpColor(lerpColor(glowCol, scorchOrange, sizzle*0.6), sunCore, glowIntensity*(shell===1?0.5:0.2));
+            g.fillStyle = rgba(sCol, sa);
+            g.beginPath(); g.moveTo(vx, midY);
+            for (let i = 0; i < BLOOM_RES; i++) {
+                const px = vx + (i/(BLOOM_RES-1))*vw;
+                g.lineTo(px, midY - upperBloom[i] * maxBloomH * expand);
+            }
+            g.lineTo(vx+vw, midY); g.closePath(); g.fill();
+            g.fillStyle = rgba(sCol, sa * 0.7);
+            g.beginPath(); g.moveTo(vx, midY);
+            for (let i = 0; i < BLOOM_RES; i++) {
+                const px = vx + (i/(BLOOM_RES-1))*vw;
+                g.lineTo(px, midY + lowerBloom[i] * maxBloomH * 0.8 * expand);
+            }
+            g.lineTo(vx+vw, midY); g.closePath(); g.fill();
+        }
+    }
+
+    const haloI = clampa(glowIntensity + sizzle*0.8 + octUp*octUp*0.15 + octDown*octDown*0.15, 0, 1);
+    if (haloI > 0.01) {
+        const warmHalo = lerpColor(lerpColor(glowCol, [255,216,112], 0.3+sizzle*0.3), [255,232,176], octUp*0.3);
+        const coolHalo = lerpColor([80,112,208], [112,80,224], octDown*0.4);
+        const offsets = [2,5,10,18,28,40], scales = [1.02,1.05,1.10,1.18,1.28,1.40];
+        const wAs = [0.10,0.08,0.06,0.04,0.025,0.015], cAs = [0.07,0.055,0.04,0.028,0.018,0.010];
+
+        for (let layer = 5; layer >= 0; layer--) {
+            const off = offsets[layer] * haloI;
+            const sc = 1 + (scales[layer]-1) * haloI;
+            const wA = wAs[layer] * haloI, cA = cAs[layer] * haloI;
+
+            for (const dir of [-1, 1]) {
+                const bl = dir < 0 ? upperBloom : lowerBloom;
+                const hm = dir < 0 ? maxBloomH : maxBloomH * 0.8;
+                g.fillStyle = rgba(warmHalo, dir < 0 ? wA : wA*0.8);
+                g.beginPath(); g.moveTo(vx-off, midY);
+                for (let i = 0; i < BLOOM_RES; i++) {
+                    const px = vx + (i/(BLOOM_RES-1))*vw - off;
+                    g.lineTo(px, midY + dir * bl[i] * hm * sc);
+                }
+                g.lineTo(vx+vw-off, midY); g.closePath(); g.fill();
+            }
+            for (const dir of [-1, 1]) {
+                const bl = dir < 0 ? upperBloom : lowerBloom;
+                const hm = dir < 0 ? maxBloomH : maxBloomH * 0.8;
+                g.fillStyle = rgba(coolHalo, dir < 0 ? cA : cA*0.8);
+                g.beginPath(); g.moveTo(vx+off, midY);
+                for (let i = 0; i < BLOOM_RES; i++) {
+                    const px = vx + (i/(BLOOM_RES-1))*vw + off;
+                    g.lineTo(px, midY + dir * bl[i] * hm * sc);
+                }
+                g.lineTo(vx+vw+off, midY); g.closePath(); g.fill();
+            }
+        }
+    }
+
+    if (octDown > 0.01) {
+        const strataCol = bloomIndigo;
+        for (let line = 0; line < 5; line++) {
+            const lineFrac = (line+1) / 6;
+            const lineY = midY + maxBloomH * 0.8 * lineFrac;
+            const pulse = Math.sin(descendThrob * 2 + line * 1.5) * 0.5 + 0.5;
+            const la = octDown * 0.12 * pulse;
+            if (la < 0.005) continue;
+            g.strokeStyle = rgba(strataCol, la);
+            g.lineWidth = 1;
+            g.beginPath();
+            let inSeg = false;
+            for (let i = 0; i < BLOOM_RES; i++) {
+                const bH = lowerBloom[i] * maxBloomH * 0.8;
+                const bBottom = midY + bH;
+                if (bBottom >= lineY && lowerBloom[i] > 0.05) {
+                    const px = vx + (i/(BLOOM_RES-1))*vw;
+                    if (!inSeg) { g.moveTo(px, lineY); inSeg = true; }
+                    else g.lineTo(px, lineY);
+                } else { inSeg = false; }
+            }
+            g.stroke();
+        }
+    }
+
+    if (noiseFrames.length > 0) {
+        const grainAlpha = 0.12 + glowIntensity*0.28 + sizzle*0.35;
+        g.globalAlpha = grainAlpha;
+        g.drawImage(noiseFrames[noiseFrameIdx], 0, 0, vizW, vizH);
+        g.globalAlpha = 1;
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SLIDER UI
+// ─────────────────────────────────────────────────────────────────────────────
+
+function updateSliderValueLabel(name) {
+    const p = params[name];
+    if (!p) return;
+    const el = document.querySelector(`[data-param-value="${name}"]`);
+    if (el) el.textContent = p.fmt(p.value);
+}
+
+function initSliders() {
+    document.querySelectorAll('.param-slider[data-param]').forEach(slider => {
+        const name = slider.dataset.param;
+        const p = params[name];
+        if (!p) return;
+        slider.value = valueToSlider(name, p.value);
+        updateSliderValueLabel(name);
+
+        slider.addEventListener('input', () => {
+            p.value = sliderToValue(name, parseFloat(slider.value));
+            updateSliderValueLabel(name);
+            applyParamsToAudio();
+        });
+    });
+}
+
+function refreshAllValueLabels() {
+    Object.keys(params).forEach(updateSliderValueLabel);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// MAIN LOOP
+// ─────────────────────────────────────────────────────────────────────────────
+
+function driftUpdate() {
+    if (!driftRunning || driftPaused) return;
+    updateDriftUI();
+    setTimeout(driftUpdate, 500);
+}
+
+function updateDriftUI() {
+    const elapsed = (Date.now() - startTime - totalPausedDuration) / 1000;
+    const mins = Math.floor(elapsed / 60), secs = Math.floor(elapsed % 60);
+    document.getElementById('elapsed').textContent = `${String(mins).padStart(2,'0')}:${String(secs).padStart(2,'0')}`;
+    document.getElementById('key').textContent = NOTE_NAMES[sacredRoot];
+    document.getElementById('mode').textContent = MODES[sacredMode].name;
+    const moodEl = document.getElementById('mood');
+    if (moodEl) moodEl.textContent = MODES[sacredMode].character || '—';
+    document.getElementById('active-voices').textContent = activeNotes;
+    document.getElementById('voice-count').textContent = '4';
+}
+
+function vizLoop() {
+    if (!driftRunning) return;
+    if (vizW !== window.innerWidth || vizH !== window.innerHeight) {
+        resizeViz();
+    }
+    updateBloomShapes();
+    paintSpectralBloom();
+    requestAnimationFrame(vizLoop);
+}
+
+function resizeViz() {
+    if (!vizCanvas) return;
+    const dpr = window.devicePixelRatio || 1;
+    const w = window.innerWidth;
+    const h = window.innerHeight;
+    vizCanvas.width = w * dpr;
+    vizCanvas.height = h * dpr;
+    vizCtx = vizCanvas.getContext('2d');
+    vizCtx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    vizW = w;
+    vizH = h;
+}
+
+function initVizCanvas() {
+    vizCanvas = document.getElementById('vizCanvas');
+    vizCtx = vizCanvas.getContext('2d');
+    resizeViz();
+    window.addEventListener('resize', resizeViz);
+}
+
+async function startApp() {
+    document.getElementById('overlay').classList.add('hidden');
+
+    initFilmGrain();
+    await initAudio();
+
+    driftRunning = true;
+    driftPaused = false;
+    startTime = Date.now();
+    totalPausedDuration = 0;
+
+    droneVoice.start();
+    setTimeout(() => { if(driftRunning) mVoice.start(); }, 1500);
+    setTimeout(() => { if(driftRunning) tVoice.start(); }, 3500);
+    setTimeout(() => { if(driftRunning) bellVoice.start(); }, 8000);
+
+    startTintAtmosphere();
+    scheduleTonalityChange();
+
+    vizCanvas.classList.add('active');
+    setTimeout(() => document.getElementById('infoOverlay').classList.add('loaded'), 800);
+    setTimeout(() => document.getElementById('sliderStack').classList.add('loaded'), 1600);
+
+    refreshAllValueLabels();
+    applyParamsToAudio();
+    driftUpdate();
+    vizLoop();
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// EVENT HANDLERS
+// ─────────────────────────────────────────────────────────────────────────────
+
+const overlay = document.getElementById('overlay');
+function triggerStart() {
+    if (overlay.classList.contains('hidden')) return;
+    startApp();
+    document.removeEventListener('keydown', triggerStart);
+    overlay.removeEventListener('click', triggerStart);
+}
+document.addEventListener('keydown', triggerStart);
+overlay.addEventListener('click', triggerStart);
+
+document.getElementById('pauseBtn').addEventListener('click', e => {
+    e.preventDefault();
+    if (!driftRunning) return;
+    if (driftPaused) {
+        driftPaused = false;
+        totalPausedDuration += Date.now() - pausedTime;
+        if (audioCtx?.state === 'suspended') audioCtx.resume();
+        document.getElementById('pauseBtn').textContent = 'pause';
+        driftUpdate();
+    } else {
+        driftPaused = true;
+        pausedTime = Date.now();
+        if (audioCtx?.state === 'running') audioCtx.suspend();
+        document.getElementById('pauseBtn').textContent = 'resume';
+    }
+});
+document.getElementById('restartBtn').addEventListener('click', e => {
+    e.preventDefault();
+    if (!driftRunning && !driftPaused) return;
+    driftRunning = false; driftPaused = false;
+    mVoice?.stop(); tVoice?.stop(); droneVoice?.stop(); bellVoice?.stop();
+    stopTintAtmosphere();
+    if(tonalityChangeTimeout){clearTimeout(tonalityChangeTimeout);tonalityChangeTimeout=null;}
+    setTimeout(startApp, 300);
+});
+
+document.getElementById('advancedToggle').addEventListener('click', () => {
+    const t = document.getElementById('advancedToggle');
+    const s = document.getElementById('advancedStack');
+    const open = !t.classList.contains('open');
+    t.classList.toggle('open', open);
+    s.classList.toggle('open', open);
+});
+
+document.addEventListener('keydown', e => {
+    if (!driftRunning && !driftPaused) return;
+    if (e.key === ' ') { e.preventDefault(); document.getElementById('pauseBtn').click(); }
+    if (e.key.toLowerCase() === 'r') { e.preventDefault(); document.getElementById('restartBtn').click(); }
+});
+
+document.addEventListener('visibilitychange', () => {
+    if (driftRunning && audioCtx && !driftPaused && audioCtx.state === 'suspended') audioCtx.resume();
+});
+setInterval(() => {
+    if (driftRunning && !driftPaused && audioCtx?.state === 'suspended') audioCtx.resume().catch(()=>{});
+}, 1000);
+
+window.addEventListener('DOMContentLoaded', () => { initVizCanvas(); initSliders(); });
+</script>
+</body>
+</html>

--- a/drift-new.html
+++ b/drift-new.html
@@ -562,6 +562,7 @@ let startTime = 0, pausedTime = 0, totalPausedDuration = 0, activeNotes = 0;
 let tintAtmosphere = { space:0.7, density:0.55, warmth:0.5, breath:0.35 };
 let tintAtmosphereTargets = { ...tintAtmosphere };
 let atmosphereInterval = null, atmosphereChangeTimeout = null, tonalityChangeTimeout = null;
+let voiceStartTimeouts = [];
 
 const rand = (a,b) => Math.random()*(b-a)+a;
 const randInt = (a,b) => Math.floor(rand(a,b+1));
@@ -715,16 +716,22 @@ function stopTintAtmosphere() {
     if(atmosphereChangeTimeout){clearTimeout(atmosphereChangeTimeout);atmosphereChangeTimeout=null;}
 }
 function scheduleTintAtmosphereChange() {
-    if(!driftRunning||driftPaused)return;
-    atmosphereChangeTimeout=setTimeout(()=>{
-        if(!driftRunning||driftPaused)return;
-        const ps=Object.keys(tintAtmosphere); const nc=Math.random()<0.4?2:1;
-        for(let i=0;i<nc;i++){
-            const p=pick(ps);
-            tintAtmosphereTargets[p]=Math.random()<0.35?(Math.random()<0.5?rand(0.12,0.3):rand(0.7,0.9)):clampa(tintAtmosphereTargets[p]+rand(-0.35,0.35),0.1,0.9);
-        }
-        scheduleTintAtmosphereChange();
-    },rand(15000,40000));
+    if(!driftRunning)return;
+    atmosphereChangeTimeout=setTimeout(runTintAtmosphereChange, rand(15000,40000));
+}
+function runTintAtmosphereChange() {
+    if(!driftRunning) return;
+    if(driftPaused) {
+        // Paused — defer the change without dropping the timer entirely
+        atmosphereChangeTimeout = setTimeout(runTintAtmosphereChange, 1000);
+        return;
+    }
+    const ps=Object.keys(tintAtmosphere); const nc=Math.random()<0.4?2:1;
+    for(let i=0;i<nc;i++){
+        const p=pick(ps);
+        tintAtmosphereTargets[p]=Math.random()<0.35?(Math.random()<0.5?rand(0.12,0.3):rand(0.7,0.9)):clampa(tintAtmosphereTargets[p]+rand(-0.35,0.35),0.1,0.9);
+    }
+    scheduleTintAtmosphereChange();
 }
 function applyTintAtmosphere() {
     if(!masterGain||!audioCtx)return; const now=audioCtx.currentTime;
@@ -736,18 +743,24 @@ function applyTintAtmosphere() {
 }
 
 function scheduleTonalityChange() {
-    if(!driftRunning||driftPaused)return;
-    tonalityChangeTimeout=setTimeout(()=>{
-        if(!driftRunning||driftPaused)return;
-        if(Math.random()<0.7){
-            sacredMode=pick(Object.keys(MODES));
-            sacredTriad=['aeolian','dorian','phrygian'].includes(sacredMode)?'minor':'major';
-        } else {
-            const mv=Math.random()<0.5?7:5, dir=Math.random()<0.5?1:-1;
-            sacredRoot=(sacredRoot+mv*dir+12)%12; lastMelodyNote=sacredRoot+60;
-        }
-        scheduleTonalityChange();
-    },rand(120000,360000));
+    if(!driftRunning)return;
+    tonalityChangeTimeout=setTimeout(runTonalityChange, rand(120000,360000));
+}
+function runTonalityChange() {
+    if(!driftRunning) return;
+    if(driftPaused) {
+        // Paused — defer rather than dropping the timer
+        tonalityChangeTimeout = setTimeout(runTonalityChange, 1000);
+        return;
+    }
+    if(Math.random()<0.7){
+        sacredMode=pick(Object.keys(MODES));
+        sacredTriad=['aeolian','dorian','phrygian'].includes(sacredMode)?'minor':'major';
+    } else {
+        const mv=Math.random()<0.5?7:5, dir=Math.random()<0.5?1:-1;
+        sacredRoot=(sacredRoot+mv*dir+12)%12; lastMelodyNote=sacredRoot+60;
+    }
+    scheduleTonalityChange();
 }
 
 // ── Apply params to audio (worklet + gain nodes + voices + atmosphere) ──────
@@ -1241,9 +1254,9 @@ async function startApp() {
     totalPausedDuration = 0;
 
     droneVoice.start();
-    setTimeout(() => { if(driftRunning) mVoice.start(); }, 1500);
-    setTimeout(() => { if(driftRunning) tVoice.start(); }, 3500);
-    setTimeout(() => { if(driftRunning) bellVoice.start(); }, 8000);
+    voiceStartTimeouts.push(setTimeout(() => { if(driftRunning) mVoice.start(); }, 1500));
+    voiceStartTimeouts.push(setTimeout(() => { if(driftRunning) tVoice.start(); }, 3500));
+    voiceStartTimeouts.push(setTimeout(() => { if(driftRunning) bellVoice.start(); }, 8000));
 
     startTintAtmosphere();
     scheduleTonalityChange();
@@ -1295,6 +1308,17 @@ document.getElementById('restartBtn').addEventListener('click', e => {
     mVoice?.stop(); tVoice?.stop(); droneVoice?.stop(); bellVoice?.stop();
     stopTintAtmosphere();
     if(tonalityChangeTimeout){clearTimeout(tonalityChangeTimeout);tonalityChangeTimeout=null;}
+    // Cancel pending deferred voice starts so they don't fire into the new session
+    voiceStartTimeouts.forEach(clearTimeout);
+    voiceStartTimeouts.length = 0;
+    // Close the previous AudioContext before startApp() creates a new one
+    if (audioCtx) {
+        try { audioCtx.close(); } catch (err) {}
+        audioCtx = null;
+        reverbWorkletNode = null;
+        inputGain = null; masterGain = null;
+        analyserNode = null;
+    }
     setTimeout(startApp, 300);
 });
 

--- a/drift-worklet-new.js
+++ b/drift-worklet-new.js
@@ -1,0 +1,1132 @@
+// ============================================================================
+// DriftReverbProcessor — AudioWorklet (experimental Drift port)
+// Mirrors current Drift plugin parameter set.
+//   Front panel: IMMERSION (mix), DISTANCE, EXPANSE (dimension/decay),
+//                FEEDBACK, MOD DEPTH, GLOW (warmth), ASCEND, DESCEND, DRIFT
+//   Advanced:    TONE, SHIMMER, STEREO WIDTH, SPATIAL (driven from page UI)
+//
+// Signal chain:
+//   Input → Pre-Diffusion (6-stage allpass)
+//   → Spatial Decorrelator (DISTANCE scales pre-delay 0.5–5×)
+//   → FDN Reverb (FEEDBACK boost + slow per-line DRIFT LFO + shimmer inject)
+//   → Pitch Shift → Shimmer LP → Energy Limiter → store shimmer
+//   → TubeSaturation (GLOW) → TiltEQ (tone) → Stereo Width
+//   → Wet Gain (-4.5 dB) → Equal-power dry/wet mix
+//   → Output HPF (20 Hz) → Output Limiter
+//
+// All internal processing in Float64Array (64-bit double precision).
+// ============================================================================
+
+const NUM_LINES = 16;
+const NUM_ALLPASS = 2;
+const HOUSEHOLDER_SCALE = 2.0 / 16.0; // 0.125
+const OUTPUT_GAIN = 1.0 / Math.sqrt(8);
+const PI = 3.14159265358979323846;
+const TWO_PI = 2.0 * PI;
+const HALF_PI = PI / 2.0;
+const WET_GAIN = Math.pow(10.0, -4.5 / 20.0); // -4.5 dB ≈ 0.5957
+
+// Prime-number fractions for FDN delay line lengths
+const PRIMES = [149, 179, 223, 263, 307, 359, 419, 491, 563, 641, 727, 839, 953, 1097, 1259, 1447];
+const PRIME_SUM = PRIMES.reduce((a, b) => a + b, 0);
+const FRACTIONS = PRIMES.map(p => p / PRIME_SUM);
+
+// FDN allpass coefficients
+const AP_COEFF_1 = 0.35;
+const AP_COEFF_2 = 0.30;
+
+// Pitch shifter constants
+const NUM_VOICES = 4;
+const NUM_GRAINS = 8;
+const GRAIN_SIZE_MS_UP = 150;
+const GRAIN_SIZE_MS_DOWN = 250;
+const PITCH_RATIOS = [2.0, 4.0, 0.5, 0.25]; // +12st, +24st, -12st, -24st
+
+// Render quantum (always 128 in Web Audio spec)
+const BLOCK_SIZE = 128;
+
+
+// ── Hermite cubic interpolation ──────────────────────────────────────────────
+function hermite(buf, posD, bufSize) {
+    const pos0 = Math.floor(posD);
+    const frac = posD - pos0;
+    let idx0 = pos0 % bufSize;
+    if (idx0 < 0) idx0 += bufSize;
+    const im1 = (idx0 - 1 + bufSize) % bufSize;
+    const ip1 = (idx0 + 1) % bufSize;
+    const ip2 = (idx0 + 2) % bufSize;
+    const y0 = buf[im1], y1 = buf[idx0], y2 = buf[ip1], y3 = buf[ip2];
+    const c0 = y1;
+    const c1 = 0.5 * (y2 - y0);
+    const c2 = y0 - 2.5 * y1 + 2.0 * y2 - 0.5 * y3;
+    const c3 = 0.5 * (y3 - y0) + 1.5 * (y1 - y2);
+    return ((c3 * frac + c2) * frac + c1) * frac + c0;
+}
+
+// ── Simple LCG PRNG ──────────────────────────────────────────────────────────
+class SimpleRng {
+    constructor(seed) { this.state = (seed === 0 ? 1 : seed) >>> 0; }
+    next() { this.state = (this.state * 1664525 + 1013904223) >>> 0; return this.state; }
+    nextDouble() { return this.next() / 4294967296.0; }
+}
+
+
+// ============================================================================
+// AllpassDiffuser — 6 cascaded allpass filters for pre-diffusion
+
+//
+// Delay times chosen to smear transients without audible echo:
+//   Stage 1:  2.1ms  g=0.50    Stage 4: 23.1ms  g=0.40
+//   Stage 2:  5.3ms  g=0.50    Stage 5: 37.9ms  g=0.35
+//   Stage 3: 11.7ms  g=0.45    Stage 6: 53.7ms  g=0.30
+//
+// setDiffusion(0–1) scales base coefficients; 0 → g≈0.05 (transparent).
+// ============================================================================
+class AllpassDiffuser {
+    constructor(sr) {
+        this.NUM_STAGES = 6;
+        this.MIN_COEFF = 0.05;
+        this.DELAY_TIMES_MS = [2.1, 5.3, 11.7, 23.1, 37.9, 53.7];
+        this.BASE_COEFFICIENTS = [0.50, 0.50, 0.45, 0.40, 0.35, 0.30];
+        this.stageCoefficients = new Float64Array(6);
+
+        // Per-channel, per-stage state: stages[ch][stage]
+        this.stages = [[], []];
+        for (let s = 0; s < 6; s++) {
+            const delaySamples = Math.max(1, Math.ceil(this.DELAY_TIMES_MS[s] * 0.001 * sr));
+            const bufferSize = delaySamples + 1;
+            for (let ch = 0; ch < 2; ch++) {
+                this.stages[ch].push({
+                    buffer: new Float64Array(bufferSize),
+                    bufferSize,
+                    delayLength: delaySamples,
+                    writePos: 0
+                });
+            }
+        }
+        this.setDiffusion(1.0);
+    }
+
+    setDiffusion(amount) {
+        const t = Math.max(0.0, Math.min(1.0, amount));
+        for (let s = 0; s < 6; s++) {
+            this.stageCoefficients[s] = this.MIN_COEFF
+                + (this.BASE_COEFFICIENTS[s] - this.MIN_COEFF) * t;
+        }
+    }
+
+    process(left, right, numSamples) {
+        const channels = [left, right];
+        for (let ch = 0; ch < 2; ch++) {
+            const data = channels[ch];
+            for (let s = 0; s < 6; s++) {
+                const ap = this.stages[ch][s];
+                const g = this.stageCoefficients[s];
+                for (let n = 0; n < numSamples; n++) {
+                    const x = data[n];
+                    let readPos = ap.writePos - ap.delayLength;
+                    if (readPos < 0) readPos += ap.bufferSize;
+                    const delayed = ap.buffer[readPos];
+                    const v = x + g * delayed;
+                    const y = delayed - g * v;
+                    ap.buffer[ap.writePos] = v;
+                    ap.writePos++;
+                    if (ap.writePos >= ap.bufferSize) ap.writePos = 0;
+                    data[n] = y;
+                }
+            }
+        }
+    }
+
+    reset() {
+        for (let ch = 0; ch < 2; ch++) {
+            for (let s = 0; s < this.stages[ch].length; s++) {
+                this.stages[ch][s].buffer.fill(0);
+                this.stages[ch][s].writePos = 0;
+            }
+        }
+    }
+}
+
+
+// ============================================================================
+// SpatialDecorator — Cross-channel modulated delay with 4-stage allpass
+
+//
+// Creates 3D depth via independent L/R delay modulation:
+//   1. Cross-feed (L↔R blend)
+//   2. Modulated stereo delay (slow LFOs at different rates per channel)
+//   3. 4-stage allpass diffusion per channel (smooths discrete echoes)
+//   4. Feedback (builds echo density)
+//
+// LFO rates: L=0.031Hz, R=0.047Hz, L2=0.073Hz, R2=0.019Hz
+// Allpass delays: [3.1, 7.3, 13.7, 21.1]ms (R channel ×1.13 for decorrelation)
+// ============================================================================
+class SpatialDecorator {
+    constructor(sr) {
+        this.sr = sr;
+        this.NUM_AP_STAGES = 4;
+        // LFO rates — very slow, irrational ratios prevent beating
+        this.LFO_RATE_L  = 0.031;
+        this.LFO_RATE_R  = 0.047;
+        this.LFO_RATE_L2 = 0.073;
+        this.LFO_RATE_R2 = 0.019;
+        const AP_DELAYS_MS = [3.1, 7.3, 13.7, 21.1];
+
+        // Delay buffers: extended to 600ms so DISTANCE (0.5–5×) can scale base delay
+        // (max base 80ms × 5 = 400ms, plus mod headroom and padding)
+        this.delayBufSize = Math.ceil(0.600 * sr) + 16;
+        this.delayBufL = new Float64Array(this.delayBufSize);
+        this.delayBufR = new Float64Array(this.delayBufSize);
+
+        // 4-stage allpass per channel
+        this.apL = [];
+        this.apR = [];
+        for (let s = 0; s < 4; s++) {
+            const apLen  = Math.max(1, Math.ceil(AP_DELAYS_MS[s] * 0.001 * sr));
+            const apLenR = Math.max(1, Math.ceil(AP_DELAYS_MS[s] * 1.13 * 0.001 * sr));
+            this.apL.push({ buffer: new Float64Array(apLen + 1),  bufferSize: apLen + 1,  delayLength: apLen,  writePos: 0 });
+            this.apR.push({ buffer: new Float64Array(apLenR + 1), bufferSize: apLenR + 1, delayLength: apLenR, writePos: 0 });
+        }
+
+        // LFO phase increments
+        this.lfoIncL  = this.LFO_RATE_L  / sr;
+        this.lfoIncR  = this.LFO_RATE_R  / sr;
+        this.lfoIncL2 = this.LFO_RATE_L2 / sr;
+        this.lfoIncR2 = this.LFO_RATE_R2 / sr;
+
+        this.reset();
+    }
+
+    setAmount(amount) {
+        this.amount01 = Math.max(0.0, Math.min(1.0, amount));
+        this.baseDelayMsRaw = 30.0 + this.amount01 * 50.0;     // 30–80ms (before DISTANCE)
+        this.baseDelayMs = this.baseDelayMsRaw * (this.distance || 1.0);
+        this.crossFeed   = this.amount01 * 0.20;                // 0–20%
+        this.feedback    = this.amount01 * 0.30;                // 0–30%
+        this.modDepthMs  = this.amount01 * 2.0;                 // 0–2ms
+        this.apCoeff     = this.amount01 * 0.55;                // 0–0.55
+    }
+
+    // DISTANCE scales the base pre-delay 0.5–5× without changing modulation depth.
+    setDistance(d) {
+        this.distance = Math.max(0.5, Math.min(5.0, d));
+        this.baseDelayMs = (this.baseDelayMsRaw || 30.0) * this.distance;
+    }
+
+    _processAllpass(ap, input, g) {
+        let readPos = ap.writePos - ap.delayLength;
+        if (readPos < 0) readPos += ap.bufferSize;
+        const delayed = ap.buffer[readPos];
+        const v = input + g * delayed;
+        const y = delayed - g * v;
+        ap.buffer[ap.writePos] = v;
+        ap.writePos++;
+        if (ap.writePos >= ap.bufferSize) ap.writePos = 0;
+        return y;
+    }
+
+    process(left, right, numSamples) {
+        if (this.amount01 < 0.001) return; // bypass when negligible
+
+        const baseDelaySamples = this.baseDelayMs * 0.001 * this.sr;
+        const modDepthSamples  = this.modDepthMs * 0.001 * this.sr;
+
+        for (let n = 0; n < numSamples; n++) {
+            const inL = left[n];
+            const inR = right[n];
+
+            // Cross-feed + feedback
+            const xfL = inL + inR * this.crossFeed + this.fbStateR * this.feedback;
+            const xfR = inR + inL * this.crossFeed + this.fbStateL * this.feedback;
+
+            // L channel modulated delay — two LFOs for complex movement
+            const modL = modDepthSamples * (
+                0.6 * Math.sin(TWO_PI * this.lfoPhaseL) +
+                0.4 * Math.sin(TWO_PI * this.lfoPhaseL2));
+            let delayL = baseDelaySamples + modL;
+            if (delayL < 1.0) delayL = 1.0;
+
+            // R channel — different LFO rates, slightly longer base delay (×1.07)
+            const modR = modDepthSamples * (
+                0.6 * Math.sin(TWO_PI * this.lfoPhaseR) +
+                0.4 * Math.sin(TWO_PI * this.lfoPhaseR2));
+            let delayR = baseDelaySamples * 1.07 + modR;
+            if (delayR < 1.0) delayR = 1.0;
+
+            // Write into delay buffers
+            this.delayBufL[this.writePos] = xfL;
+            this.delayBufR[this.writePos] = xfR;
+
+            // Read with Hermite interpolation
+            let posL = this.writePos - delayL;
+            while (posL < 0.0) posL += this.delayBufSize;
+            let tapL = hermite(this.delayBufL, posL, this.delayBufSize);
+
+            let posR = this.writePos - delayR;
+            while (posR < 0.0) posR += this.delayBufSize;
+            let tapR = hermite(this.delayBufR, posR, this.delayBufSize);
+
+            // 4-stage allpass diffusion per channel
+            for (let s = 0; s < 4; s++) {
+                tapL = this._processAllpass(this.apL[s], tapL, this.apCoeff);
+                tapR = this._processAllpass(this.apR[s], tapR, this.apCoeff);
+            }
+
+            // Store feedback state
+            this.fbStateL = tapL;
+            this.fbStateR = tapR;
+
+            // Advance LFOs
+            this.lfoPhaseL  += this.lfoIncL;  if (this.lfoPhaseL  >= 1.0) this.lfoPhaseL  -= 1.0;
+            this.lfoPhaseR  += this.lfoIncR;  if (this.lfoPhaseR  >= 1.0) this.lfoPhaseR  -= 1.0;
+            this.lfoPhaseL2 += this.lfoIncL2; if (this.lfoPhaseL2 >= 1.0) this.lfoPhaseL2 -= 1.0;
+            this.lfoPhaseR2 += this.lfoIncR2; if (this.lfoPhaseR2 >= 1.0) this.lfoPhaseR2 -= 1.0;
+
+            // Advance write pointer
+            this.writePos++;
+            if (this.writePos >= this.delayBufSize) this.writePos = 0;
+
+            // Crossfade between dry and processed
+            left[n]  = inL * (1.0 - this.amount01) + tapL * this.amount01;
+            right[n] = inR * (1.0 - this.amount01) + tapR * this.amount01;
+        }
+    }
+
+    reset() {
+        this.delayBufL.fill(0);
+        this.delayBufR.fill(0);
+        this.writePos = 0;
+        this.fbStateL = 0.0;
+        this.fbStateR = 0.0;
+        this.lfoPhaseL  = 0.0;
+        this.lfoPhaseR  = 0.25;  // offset for stereo decorrelation
+        this.lfoPhaseL2 = 0.5;
+        this.lfoPhaseR2 = 0.75;
+        this.amount01      = 0.0;
+        this.baseDelayMsRaw = 30.0;
+        this.baseDelayMs    = 30.0;
+        this.distance       = 1.0;
+        this.crossFeed   = 0.0;
+        this.feedback    = 0.0;
+        this.modDepthMs  = 0.0;
+        this.apCoeff     = 0.0;
+        for (let s = 0; s < 4; s++) {
+            this.apL[s].buffer.fill(0); this.apL[s].writePos = 0;
+            this.apR[s].buffer.fill(0); this.apR[s].writePos = 0;
+        }
+    }
+}
+
+
+// ============================================================================
+// FDN Reverb — 16-line Householder with nested allpass, Jot RT60 damping
+// ============================================================================
+class FDNReverb {
+    constructor(sr) {
+        this.sr = sr;
+        this.lines = [];
+        this.panCoeff = new Float64Array(NUM_LINES);
+        this.fbScale = new Float64Array(NUM_LINES);
+        this.dampLpCoeff = new Float64Array(NUM_LINES);
+        this.dampGain = new Float64Array(NUM_LINES);
+        this.currentDelaySamples = new Float64Array(NUM_LINES);
+        this.currentFeedback = 1.0;
+        this.isFrozen = false;
+        this.currentModDepthNorm = 0.3;
+
+        // LFO state
+        this.lfoRng = new SimpleRng(42);
+        this.lfoState = new Float64Array(NUM_LINES);
+        this.lfoFiltered = new Float64Array(NUM_LINES);
+        this.lfoSmoothCoeff = new Float64Array(NUM_LINES);
+        this.lfoStepScale = new Float64Array(NUM_LINES);
+
+        // DRIFT — slow per-line random walk on delay length (much slower than modDepth LFO)
+        this.driftRng = new SimpleRng(2024);
+        this.driftLfoState    = new Float64Array(NUM_LINES);
+        this.driftLfoFiltered = new Float64Array(NUM_LINES);
+        this.driftLfoSmoothCoeff = new Float64Array(NUM_LINES);
+        this.driftLfoStepScale   = new Float64Array(NUM_LINES);
+        this.driftAmount = 0.0;
+
+        // FEEDBACK — scales fb[i] regen amount above natural damping (0–2.5%)
+        this.feedbackBoost = 0.0;
+
+        // Shimmer injection buffers
+        this.shimmerInL = new Float64Array(BLOCK_SIZE);
+        this.shimmerInR = new Float64Array(BLOCK_SIZE);
+
+        // Pre-allocate per-sample work arrays (avoids GC in process loop)
+        this._tapOut  = new Float64Array(NUM_LINES);
+        this._mixed   = new Float64Array(NUM_LINES);
+        this._feedback = new Float64Array(NUM_LINES);
+
+        const maxDelay = Math.ceil(1.1 * sr) + 16;
+
+        for (let i = 0; i < NUM_LINES; i++) {
+            const lineScale = 0.8 + 0.4 * i / 15.0;
+            const ap1Delay = Math.max(1, Math.ceil(0.0013 * lineScale * sr));
+            const ap2Delay = Math.max(1, Math.ceil(0.0029 * lineScale * sr));
+
+            this.lines.push({
+                buffer: new Float64Array(maxDelay),
+                bufferSize: maxDelay,
+                writePos: 0,
+                lpState1: 0, lpState2: 0,
+                dcState: 0, dcPrevInput: 0,
+                ap: [
+                    { buffer: new Float64Array(ap1Delay + 1), bufferSize: ap1Delay + 1, delayLength: ap1Delay, writePos: 0 },
+                    { buffer: new Float64Array(ap2Delay + 1), bufferSize: ap2Delay + 1, delayLength: ap2Delay, writePos: 0 },
+                ]
+            });
+
+            this.panCoeff[i] = i / (NUM_LINES - 1);
+            this.fbScale[i] = 0.97 + 0.06 * i / 15.0;
+            const rate = 0.05 + 0.15 * i / 15.0;
+            this.lfoSmoothCoeff[i] = Math.exp(-TWO_PI * 2.0 / sr);
+            this.lfoStepScale[i] = rate * 0.01;
+            // drift: smoothing pole near 0.05Hz, step is ~25× smaller than fast LFO
+            this.driftLfoSmoothCoeff[i] = Math.exp(-TWO_PI * 0.08 / sr);
+            this.driftLfoStepScale[i] = (0.05 + 0.10 * i / 15.0) * 0.0004;
+        }
+
+        this.setSize(0.65);
+        this.computeDamping(2.0, 3.0, 1.0);
+    }
+
+    setSize(size) {
+        const totalMs = 250 * Math.pow(6000 / 250, size);
+        for (let i = 0; i < NUM_LINES; i++) {
+            this.currentDelaySamples[i] = Math.max(1, FRACTIONS[i] * totalMs * 0.001 * this.sr);
+        }
+    }
+
+    setModDepth(d) { this.currentModDepthNorm = d; }
+    setFreeze(f) { this.isFrozen = f; }
+    setFeedback(f) { this.feedbackBoost = Math.max(0, Math.min(1, f)); }
+    setDrift(d) { this.driftAmount = Math.max(0, Math.min(1, d)); }
+
+    computeDamping(t60Low, t60Mid, t60High) {
+        t60Low  = Math.max(0.05, t60Low);
+        t60Mid  = Math.max(0.05, t60Mid);
+        t60High = Math.max(0.05, t60High);
+        for (let i = 0; i < NUM_LINES; i++) {
+            const d = Math.max(1, this.currentDelaySamples[i]);
+            let gMid = Math.pow(10, -3.0 * d / (t60Mid * this.sr));
+            gMid = Math.min(0.9999, Math.max(0, gMid));
+            this.dampGain[i] = gMid;
+            const fc = 3000 + 7000 * (1 - i / 15.0);
+            this.dampLpCoeff[i] = Math.exp(-TWO_PI * fc / this.sr);
+        }
+    }
+
+    setDecayParams(decaySec, hfDecayRatio) {
+        const tNorm = Math.max(0, Math.min(1, (decaySec - 0.1) / 59.9));
+        this.setSize(Math.sqrt(tNorm));
+        this.computeDamping(decaySec * 1.05, decaySec, decaySec * hfDecayRatio);
+    }
+
+    processAllpass(ap, input, g) {
+        let readPos = ap.writePos - ap.delayLength;
+        if (readPos < 0) readPos += ap.bufferSize;
+        const delayed = ap.buffer[readPos];
+        const v = input + g * delayed;
+        const y = delayed - g * v;
+        ap.buffer[ap.writePos] = v;
+        ap.writePos = (ap.writePos + 1) % ap.bufferSize;
+        return y;
+    }
+
+    process(left, right, numSamples) {
+        const tapOut  = this._tapOut;
+        const mixed   = this._mixed;
+        const fb      = this._feedback;
+
+        for (let n = 0; n < numSamples; n++) {
+            // Read from delay lines with modulation + allpass
+            for (let i = 0; i < NUM_LINES; i++) {
+                const line = this.lines[i];
+                // Random-walk LFO
+                const rv = this.lfoRng.next();
+                const rs = (rv / 4294967296.0 - 0.5) * 2.0;
+                this.lfoState[i] = Math.max(-1, Math.min(1,
+                    this.lfoState[i] + rs * this.lfoStepScale[i]));
+                this.lfoFiltered[i] = this.lfoSmoothCoeff[i] * this.lfoFiltered[i]
+                    + (1 - this.lfoSmoothCoeff[i]) * this.lfoState[i];
+
+                const lineModDepth = this.currentDelaySamples[i] * 0.02 * this.currentModDepthNorm;
+                const modSamples = this.lfoFiltered[i] * lineModDepth;
+
+                // DRIFT — slow independent random walk on delay length
+                const drv = this.driftRng.next();
+                const drs = (drv / 4294967296.0 - 0.5) * 2.0;
+                this.driftLfoState[i] = Math.max(-1, Math.min(1,
+                    this.driftLfoState[i] + drs * this.driftLfoStepScale[i]));
+                this.driftLfoFiltered[i] = this.driftLfoSmoothCoeff[i] * this.driftLfoFiltered[i]
+                    + (1 - this.driftLfoSmoothCoeff[i]) * this.driftLfoState[i];
+                const driftMod = this.driftLfoFiltered[i] * this.currentDelaySamples[i]
+                    * 0.04 * this.driftAmount;
+
+                const totalDelay = this.currentDelaySamples[i] + modSamples + driftMod;
+
+                let readPosD = line.writePos - totalDelay;
+                if (readPosD < 0) readPosD += line.bufferSize;
+
+                let tap = hermite(line.buffer, readPosD, line.bufferSize);
+                tap = this.processAllpass(line.ap[0], tap, AP_COEFF_1);
+                tap = this.processAllpass(line.ap[1], tap, AP_COEFF_2);
+                tapOut[i] = tap;
+            }
+
+            // Householder mixing
+            let sum = 0;
+            for (let i = 0; i < NUM_LINES; i++) sum += tapOut[i];
+            const scaledSum = sum * HOUSEHOLDER_SCALE;
+            for (let i = 0; i < NUM_LINES; i++) mixed[i] = tapOut[i] - scaledSum;
+
+            // Per-line damping + DC blocker
+            for (let i = 0; i < NUM_LINES; i++) {
+                const line = this.lines[i];
+                line.lpState1 = (1 - this.dampLpCoeff[i]) * mixed[i]
+                    + this.dampLpCoeff[i] * line.lpState1;
+                line.lpState2 = (1 - this.dampLpCoeff[i]) * line.lpState1
+                    + this.dampLpCoeff[i] * line.lpState2;
+                let damped = line.lpState2 * this.dampGain[i];
+                // DC blocker
+                const dcIn = damped;
+                const dcOut = dcIn - line.dcPrevInput + 0.9995 * line.dcState;
+                line.dcPrevInput = dcIn;
+                line.dcState = dcOut;
+                fb[i] = this.isFrozen
+                    ? (dcOut * this.fbScale[i])
+                    : (dcOut * this.currentFeedback * this.fbScale[i]
+                        * (1.0 + this.feedbackBoost * 0.025));
+            }
+
+            // Inject input + shimmer
+            const inL = left[n], inR = right[n];
+            const shimL = n < this.shimmerInL.length ? this.shimmerInL[n] : 0;
+            const shimR = n < this.shimmerInR.length ? this.shimmerInR[n] : 0;
+
+            for (let i = 0; i < NUM_LINES; i++) {
+                const pan = this.panCoeff[i];
+                const inp = inL * (1 - pan) + inR * pan;
+                const shim = shimL * (1 - pan) + shimR * pan;
+                this.lines[i].buffer[this.lines[i].writePos] = inp + fb[i] + shim;
+                this.lines[i].writePos = (this.lines[i].writePos + 1)
+                    % this.lines[i].bufferSize;
+            }
+
+            // Output: sum with stereo panning
+            let outL = 0, outR = 0;
+            for (let i = 0; i < NUM_LINES; i++) {
+                outL += tapOut[i] * (1 - this.panCoeff[i]);
+                outR += tapOut[i] * this.panCoeff[i];
+            }
+            left[n]  = outL * OUTPUT_GAIN;
+            right[n] = outR * OUTPUT_GAIN;
+        }
+    }
+}
+
+
+// ============================================================================
+// Granular Pitch Shifter — 4 voices × 8 grains, Hann window, Hermite interp
+// ============================================================================
+class GranularPitchShifter {
+    constructor(sr, seed) {
+        this.sr = sr;
+        this.rng = new SimpleRng(seed);
+        this.grainSizeUp = Math.ceil(GRAIN_SIZE_MS_UP * 0.001 * sr);
+        this.grainSizeDown = Math.ceil(GRAIN_SIZE_MS_DOWN * 0.001 * sr);
+        this.grainSpacingUp = Math.floor(this.grainSizeUp / NUM_GRAINS);
+        this.grainSpacingDown = Math.floor(this.grainSizeDown / NUM_GRAINS);
+
+        // Input circular buffer
+        this.bufSize = this.grainSizeDown * 8;
+        this.buffer = new Float64Array(this.bufSize);
+        this.writePos = 0;
+
+        // Hann windows
+        this.hannUp = new Float32Array(this.grainSizeUp);
+        for (let i = 0; i < this.grainSizeUp; i++)
+            this.hannUp[i] = 0.5 * (1 - Math.cos(TWO_PI * i / this.grainSizeUp));
+        this.hannDown = new Float32Array(this.grainSizeDown);
+        for (let i = 0; i < this.grainSizeDown; i++)
+            this.hannDown[i] = 0.5 * (1 - Math.cos(TWO_PI * i / this.grainSizeDown));
+
+        // Grain state: [voice][grain]
+        this.grains = [];
+        const phaseOffset = (seed * 7) % Math.max(1, this.grainSpacingUp);
+        for (let v = 0; v < NUM_VOICES; v++) {
+            const isDown = v >= 2;
+            const gs = isDown ? this.grainSizeDown : this.grainSizeUp;
+            const sp = isDown ? this.grainSpacingDown : this.grainSpacingUp;
+            this.grains.push([]);
+            for (let g = 0; g < NUM_GRAINS; g++) {
+                this.grains[v].push({
+                    readPos: 0,
+                    samplesActive: (g * sp + phaseOffset) % gs
+                });
+            }
+        }
+
+        this.oct1UpGain = 0;
+        this.oct2UpGain = 0;
+        this.oct1DownGain = 0;
+        this.oct2DownGain = 0;
+    }
+
+    resetGrain(g, v) {
+        const isDown = v >= 2;
+        const gs = isDown ? this.grainSizeDown : this.grainSizeUp;
+        const sp = isDown ? this.grainSpacingDown : this.grainSpacingUp;
+        let startPos = this.writePos - gs
+            + (this.rng.nextDouble() - 0.5) * 0.5 * sp
+            + this.rng.nextDouble() * 0.3 * sp;
+        while (startPos < 0) startPos += this.bufSize;
+        while (startPos >= this.bufSize) startPos -= this.bufSize;
+        g.readPos = startPos;
+        g.samplesActive = 0;
+    }
+
+    process(input, output, numSamples) {
+        for (let n = 0; n < numSamples; n++) {
+            this.buffer[this.writePos] = input[n];
+            let out = 0;
+
+            for (let v = 0; v < NUM_VOICES; v++) {
+                const isDown = v >= 2;
+                const gs = isDown ? this.grainSizeDown : this.grainSizeUp;
+                const hann = isDown ? this.hannDown : this.hannUp;
+                let voiceOut = 0;
+
+                for (let g = 0; g < NUM_GRAINS; g++) {
+                    const gr = this.grains[v][g];
+                    if (gr.samplesActive >= gs) this.resetGrain(gr, v);
+                    const w = hann[gr.samplesActive];
+                    let rp = gr.readPos;
+                    while (rp < 0) rp += this.bufSize;
+                    while (rp >= this.bufSize) rp -= this.bufSize;
+                    voiceOut += hermite(this.buffer, rp, this.bufSize) * w;
+                    gr.readPos += PITCH_RATIOS[v];
+                    if (gr.readPos >= this.bufSize) gr.readPos -= this.bufSize;
+                    gr.samplesActive++;
+                }
+                voiceOut *= 0.25; // normalize (1/4 for 8 Hann grains summing to ~4)
+
+                const gains = [this.oct1UpGain, this.oct2UpGain,
+                               this.oct1DownGain, this.oct2DownGain];
+                out += voiceOut * gains[v];
+            }
+
+            output[n] = out;
+            this.writePos = (this.writePos + 1) % this.bufSize;
+        }
+    }
+}
+
+
+// ============================================================================
+// FeedbackEnergyLimiter — RMS envelope follower with gain reduction
+
+//
+// Prevents shimmer runaway at high shimmer + high decay settings.
+//   - One-pole envelope follower tracks stereo RMS (~10ms window)
+//   - Gain reduction when RMS > threshold
+//   - Attack ~1ms (fast) / Release ~50ms (slow) for transparent limiting
+// ============================================================================
+class FeedbackEnergyLimiter {
+    constructor(sr) {
+        this.rmsAlpha    = 1.0 - Math.exp(-1.0 / (0.010 * sr)); // 10ms RMS window
+        this.attackCoeff = 1.0 - Math.exp(-1.0 / (0.001 * sr)); // 1ms attack
+        this.releaseCoeff = 1.0 - Math.exp(-1.0 / (0.050 * sr)); // 50ms release
+        this.rmsLevel    = 0.0;
+        this.currentGain = 1.0;
+    }
+
+    process(left, right, numSamples, threshold) {
+        if (threshold === undefined) threshold = 0.9;
+        for (let n = 0; n < numSamples; n++) {
+            // Track RMS energy (stereo sum of squares)
+            const energy = left[n] * left[n] + right[n] * right[n];
+            this.rmsLevel += this.rmsAlpha * (energy - this.rmsLevel);
+            if (this.rmsLevel < 0.0) this.rmsLevel = 0.0;
+
+            const rms = Math.sqrt(this.rmsLevel);
+
+            // Compute target gain: reduce if above threshold
+            const targetGain = (rms > threshold) ? (threshold / rms) : 1.0;
+
+            // Smooth gain: fast attack, slow release
+            const coeff = (targetGain < this.currentGain)
+                ? this.attackCoeff : this.releaseCoeff;
+            this.currentGain += coeff * (targetGain - this.currentGain);
+
+            left[n]  *= this.currentGain;
+            right[n] *= this.currentGain;
+        }
+    }
+
+    reset() {
+        this.rmsLevel    = 0.0;
+        this.currentGain = 1.0;
+    }
+}
+
+
+// ============================================================================
+// TubeSaturation — 3-stage tube character (warmth/glow)
+// Port of TubeSaturation.h
+//
+// Amount 0.0 (clean) → 1.0 (full tube limiter):
+//   1. Tube compression:  RMS compressor, threshold 1.0→0.15, ratio 1:1→10:1
+//   2. Tube saturation:   Asymmetric tanh, drive 1×→6×, even-harmonic warmth
+//   3. HF rolloff:        One-pole LP, 20kHz→6kHz (tape head character)
+// ============================================================================
+class TubeSaturation {
+    constructor(sr) {
+        this.sr = sr;
+        // Envelope follower coefficients
+        this.envAttack  = Math.exp(-1.0 / (sr * 0.002));  // 2ms attack
+        this.envRelease = Math.exp(-1.0 / (sr * 0.200));  // 200ms release
+        this.rmsCoeff   = Math.exp(-1.0 / (sr * 0.010));  // 10ms RMS window
+        this.reset();
+    }
+
+    setAmount(amount) {
+        this.amount01 = Math.max(0.0, Math.min(1.0, amount));
+
+        // Compressor: threshold 1.0→0.15, ratio 1:1→10:1
+        this.compThreshold = 1.0 - this.amount01 * 0.85;
+        this.compRatio     = 1.0 + this.amount01 * 9.0;
+
+        // Saturation: drive 1×→6×
+        this.satDrive  = 1.0 + this.amount01 * 5.0;
+        this.satMakeup = 1.0 / Math.max(0.3, Math.tanh(this.satDrive * 0.7));
+
+        // HF rolloff: 20kHz→6kHz
+        const cutoffHz = 20000.0 * Math.pow(0.3, this.amount01);
+        const wc = 2.0 * PI * cutoffHz / this.sr;
+        this.lpCoeff = Math.exp(-wc);
+    }
+
+    _saturate(x) {
+        const driven = x * this.satDrive;
+        let shaped;
+        if (driven >= 0.0) {
+            shaped = Math.tanh(driven);
+        } else {
+            // Negative half driven 15% harder → asymmetry → even harmonics
+            shaped = Math.tanh(driven * 1.15) / 1.15;
+        }
+        // Subtle Gaussian bias for extra 2nd-harmonic content
+        const bias = 0.08 * (this.satDrive - 1.0) / 5.0
+            * Math.exp(-driven * driven * 0.5);
+        return (shaped + bias) * this.satMakeup;
+    }
+
+    process(left, right, numSamples) {
+        for (let n = 0; n < numSamples; n++) {
+            let L = left[n];
+            let R = right[n];
+
+            // ── Stage 1: Tube Compression / Limiting ──
+            {
+                const mono = (L + R) * 0.5;
+                const sq = mono * mono;
+                this.rmsEnvelope = this.rmsCoeff * this.rmsEnvelope
+                    + (1.0 - this.rmsCoeff) * sq;
+                const rmsLevel = Math.sqrt(this.rmsEnvelope);
+
+                let gainReduction = 1.0;
+                if (rmsLevel > this.compThreshold && this.compThreshold > 0.0) {
+                    const overshoot = rmsLevel / this.compThreshold;
+                    const exponent = (1.0 / this.compRatio) - 1.0;
+                    gainReduction = Math.pow(overshoot, exponent);
+                }
+
+                if (gainReduction < this.compGainSmoothed)
+                    this.compGainSmoothed = this.envAttack * this.compGainSmoothed
+                        + (1.0 - this.envAttack) * gainReduction;
+                else
+                    this.compGainSmoothed = this.envRelease * this.compGainSmoothed
+                        + (1.0 - this.envRelease) * gainReduction;
+
+                L *= this.compGainSmoothed;
+                R *= this.compGainSmoothed;
+            }
+
+            // ── Stage 2: Tube Saturation ──
+            L = this._saturate(L);
+            R = this._saturate(R);
+
+            // ── Stage 3: HF Rolloff (one-pole LP) ──
+            this.lpStateL = (1.0 - this.lpCoeff) * L + this.lpCoeff * this.lpStateL;
+            L = this.lpStateL;
+            this.lpStateR = (1.0 - this.lpCoeff) * R + this.lpCoeff * this.lpStateR;
+            R = this.lpStateR;
+
+            left[n]  = L;
+            right[n] = R;
+        }
+    }
+
+    reset() {
+        this.amount01         = 0.0;
+        this.compThreshold    = 1.0;
+        this.compRatio        = 1.0;
+        this.satDrive         = 1.0;
+        this.satMakeup        = 1.0;
+        this.lpCoeff          = 0.0;
+        this.rmsEnvelope      = 0.0;
+        this.compGainSmoothed = 1.0;
+        this.lpStateL         = 0.0;
+        this.lpStateR         = 0.0;
+    }
+}
+
+
+// ============================================================================
+// TiltEQ — First-order crossover tilt at 1 kHz pivot
+
+//
+// Splits signal into LP + HP bands via one-pole crossover, applies
+// complementary gain.  V = 10^(|dB|/40) — half the total tilt per side.
+//   Negative dB → dark (lows up, highs down)
+//   0 dB        → flat
+//   Positive dB → bright (highs up, lows down)
+// ============================================================================
+class TiltEQ {
+    constructor(sr) {
+        // First-order LP coefficient at 1000 Hz crossover
+        const wc = 2.0 * PI * 1000.0 / sr;
+        this.lpCoeff  = Math.exp(-wc);
+        this.lowGain  = 1.0;
+        this.highGain = 1.0;
+        this.stateL   = 0.0;
+        this.stateR   = 0.0;
+    }
+
+    setTilt(tiltDb) {
+        const dB = Math.max(-12.0, Math.min(12.0, tiltDb));
+        const V = Math.pow(10.0, Math.abs(dB) / 40.0);
+        if (dB >= 0.0) {
+            this.highGain = V;
+            this.lowGain  = 1.0 / V;
+        } else {
+            this.lowGain  = V;
+            this.highGain = 1.0 / V;
+        }
+    }
+
+    process(left, right, numSamples) {
+        for (let n = 0; n < numSamples; n++) {
+            // Left: split into LP + HP, apply tilt gains
+            this.stateL = (1.0 - this.lpCoeff) * left[n] + this.lpCoeff * this.stateL;
+            const hpL = left[n] - this.stateL;
+            left[n] = this.stateL * this.lowGain + hpL * this.highGain;
+
+            // Right
+            this.stateR = (1.0 - this.lpCoeff) * right[n] + this.lpCoeff * this.stateR;
+            const hpR = right[n] - this.stateR;
+            right[n] = this.stateR * this.lowGain + hpR * this.highGain;
+        }
+    }
+
+    reset() {
+        this.stateL = 0.0;
+        this.stateR = 0.0;
+    }
+}
+
+
+// ============================================================================
+// StereoWidthProcessor — Mid/side encoding with width control
+
+//
+// Stateless. Width semantics:
+//   0.0       = mono  (side zeroed)
+//   1.0       = unity (no change)
+//   1.0–2.0   = "clear center" (mid fades out, side boosted)
+//   2.0       = pure sides (mid removed)
+// ============================================================================
+class StereoWidthProcessor {
+    process(left, right, numSamples, width) {
+        for (let n = 0; n < numSamples; n++) {
+            const mid  = (left[n] + right[n]) * 0.5;
+            const side = (left[n] - right[n]) * 0.5;
+
+            const midGain  = width <= 1.0 ? 1.0 : Math.max(0.0, 2.0 - width);
+            const sideGain = width;
+
+            left[n]  = mid * midGain + side * sideGain;
+            right[n] = mid * midGain - side * sideGain;
+        }
+    }
+}
+
+
+// ============================================================================
+// GlowReverbProcessor — AudioWorklet main processor
+// ============================================================================
+class GlowReverbProcessor extends AudioWorkletProcessor {
+    static get parameterDescriptors() {
+        return [
+            // Front-panel (mirrors Drift plugin defaults from screenshot)
+            { name: 'mix',          defaultValue: 0.30, minValue: 0,    maxValue: 1,  automationRate: 'k-rate' },
+            { name: 'distance',     defaultValue: 2.75, minValue: 0.5,  maxValue: 5,  automationRate: 'k-rate' },
+            { name: 'dimension',    defaultValue: 5.0,  minValue: 0.1,  maxValue: 60, automationRate: 'k-rate' },
+            { name: 'feedback',     defaultValue: 0,    minValue: 0,    maxValue: 1,  automationRate: 'k-rate' },
+            { name: 'modDepth',     defaultValue: 0.40, minValue: 0,    maxValue: 1,  automationRate: 'k-rate' },
+            { name: 'warmth',       defaultValue: 0.10, minValue: 0,    maxValue: 1,  automationRate: 'k-rate' },
+            { name: 'octUp',        defaultValue: 0.10, minValue: 0,    maxValue: 1,  automationRate: 'k-rate' },
+            { name: 'octDown',      defaultValue: 0,    minValue: 0,    maxValue: 1,  automationRate: 'k-rate' },
+            { name: 'drift',        defaultValue: 0.10, minValue: 0,    maxValue: 1,  automationRate: 'k-rate' },
+            // Advanced panel
+            { name: 'shimmerLevel', defaultValue: 0.25, minValue: 0,    maxValue: 1,  automationRate: 'k-rate' },
+            { name: 'tone',         defaultValue: 0,    minValue: -1,   maxValue: 1,  automationRate: 'k-rate' },
+            { name: 'stereoWidth',  defaultValue: 1.0,  minValue: 0,    maxValue: 2,  automationRate: 'k-rate' },
+            { name: 'spatial',      defaultValue: 0.4,  minValue: 0,    maxValue: 1,  automationRate: 'k-rate' },
+        ];
+    }
+
+    constructor() {
+        super();
+        const sr = sampleRate;
+
+        // ── DSP modules ──
+        this.diffuser       = new AllpassDiffuser(sr);
+        this.spatial        = new SpatialDecorator(sr);
+        this.fdn            = new FDNReverb(sr);
+        this.pitchL         = new GranularPitchShifter(sr, 42);
+        this.pitchR         = new GranularPitchShifter(sr, 12345);
+        this.energyLimiter  = new FeedbackEnergyLimiter(sr);
+        this.tubeSaturation    = new TubeSaturation(sr);
+        this.tiltEQ         = new TiltEQ(sr);
+        this.stereoWidth    = new StereoWidthProcessor();
+
+        // ── Shimmer buffers ──
+        this.shimmerBufL  = new Float64Array(BLOCK_SIZE);
+        this.shimmerBufR  = new Float64Array(BLOCK_SIZE);
+        this.prevShimmerL = new Float64Array(BLOCK_SIZE);
+        this.prevShimmerR = new Float64Array(BLOCK_SIZE);
+
+        // ── Shimmer LP filter state (one-pole lowpass, adaptive cutoff) ──
+        this.shimmerLpStateL = 0.0;
+        this.shimmerLpStateR = 0.0;
+
+        // ── Output HPF state (20 Hz DC blocker, second-order) ──
+        // Implemented as a first-order HP: y[n] = x[n] - x[n-1] + R * y[n-1]
+        // R = 1 - (2π × 20 / sr)
+        this.hpfR = 1.0 - (TWO_PI * 20.0 / sr);
+        this.hpfPrevInL  = 0.0;
+        this.hpfPrevInR  = 0.0;
+        this.hpfPrevOutL = 0.0;
+        this.hpfPrevOutR = 0.0;
+
+        // ── Output limiter envelope ──
+        this.limiterEnv = 0.0;
+
+        // ── Cached parameter for change detection ──
+        this.lastDimension = -1;
+
+        // ── Pre-allocate work buffers (avoid GC in process) ──
+        this._dryL = new Float64Array(BLOCK_SIZE);
+        this._dryR = new Float64Array(BLOCK_SIZE);
+        this._wetL = new Float64Array(BLOCK_SIZE);
+        this._wetR = new Float64Array(BLOCK_SIZE);
+        this._fdnOutL = new Float64Array(BLOCK_SIZE);
+        this._fdnOutR = new Float64Array(BLOCK_SIZE);
+
+        // ── Set diffuser to density=1.0 (full pre-diffusion) ──
+        this.diffuser.setDiffusion(1.0);
+    }
+
+    process(inputs, outputs, parameters) {
+        const input = inputs[0];
+        const output = outputs[0];
+        if (!input || !input[0] || !output || !output[0]) return true;
+
+        const numSamples = output[0].length;
+        const inL = input[0], inR = input[1] || input[0];
+        const outL = output[0], outR = output[1] || output[0];
+
+        // ── Read parameters ──
+        const mix          = parameters.mix[0];
+        const distance     = parameters.distance[0];
+        const dimension    = parameters.dimension[0];
+        const feedback     = parameters.feedback[0];
+        const octUp        = parameters.octUp[0];
+        const octDown      = parameters.octDown[0];
+        const modDepth     = parameters.modDepth[0];
+        const warmth       = parameters.warmth[0];
+        const driftAmt     = parameters.drift[0];
+        const shimmerLevel = parameters.shimmerLevel[0];
+        const tone         = parameters.tone[0];
+        const stereoWidth  = parameters.stereoWidth[0];
+        const spatialAmt   = parameters.spatial[0];
+
+        // ── Update FDN decay if dimension changed ──
+        if (Math.abs(dimension - this.lastDimension) > 0.01) {
+            this.lastDimension = dimension;
+            this.fdn.setDecayParams(dimension, 0.3);
+        }
+        this.fdn.setModDepth(modDepth);
+
+        // ── Set pitch shifter gains (75% breakpoint mapping like plugin) ──
+        const oct1Up   = Math.min(octUp / 0.75, 1.0);
+        const oct2Up   = Math.max((octUp - 0.75) / 0.25, 0.0);
+        const oct1Down = Math.min(octDown / 0.75, 1.0);
+        const oct2Down = Math.max((octDown - 0.75) / 0.25, 0.0);
+        this.pitchL.oct1UpGain = oct1Up; this.pitchL.oct2UpGain = oct2Up;
+        this.pitchL.oct1DownGain = oct1Down; this.pitchL.oct2DownGain = oct2Down;
+        this.pitchR.oct1UpGain = oct1Up; this.pitchR.oct2UpGain = oct2Up;
+        this.pitchR.oct1DownGain = oct1Down; this.pitchR.oct2DownGain = oct2Down;
+
+        // ── Update spatial decorrelator (DISTANCE applied first so setAmount sees it) ──
+        this.spatial.setDistance(distance);
+        this.spatial.setAmount(spatialAmt);
+
+        // ── Update FDN extras (FEEDBACK regen + DRIFT slow LFO) ──
+        this.fdn.setFeedback(feedback);
+        this.fdn.setDrift(driftAmt);
+
+        // ── Update TubeSaturation (warmth) ──
+        this.tubeSaturation.setAmount(warmth);
+
+        // ── Update TiltEQ: tone -1..+1 → -6..+6 dB ──
+        this.tiltEQ.setTilt(tone * 6.0);
+
+        // ── Compute adaptive shimmer LP coefficient ──
+        // Cutoff sweeps from 6kHz (octUp=0) to 2.5kHz (octUp=1)
+        const shimmerLpCutoff = 6000.0 - octUp * 3500.0; // 6000 → 2500 Hz
+        const shimmerLpWc = TWO_PI * shimmerLpCutoff / sampleRate;
+        const shimmerLpCoeff = Math.exp(-shimmerLpWc);
+
+        // ── Copy dry signal + prepare wet ──
+        const dryL = this._dryL;
+        const dryR = this._dryR;
+        const wetL = this._wetL;
+        const wetR = this._wetR;
+        for (let i = 0; i < numSamples; i++) {
+            dryL[i] = inL[i]; dryR[i] = inR[i];
+            wetL[i] = inL[i]; wetR[i] = inR[i];
+        }
+
+        // ════════════════════════════════════════════════════════════════
+        // SIGNAL CHAIN
+        // ════════════════════════════════════════════════════════════════
+
+        // ── 1. Pre-Diffusion (6-stage cascaded allpass, density=1.0) ──
+        this.diffuser.process(wetL, wetR, numSamples);
+
+        // ── 2. Spatial Decorrelator ──
+        this.spatial.process(wetL, wetR, numSamples);
+
+        // ── 3. Inject previous block's shimmer into FDN ──
+        const shimBufSize = Math.min(numSamples, this.fdn.shimmerInL.length);
+        for (let i = 0; i < shimBufSize; i++) {
+            this.fdn.shimmerInL[i] = this.prevShimmerL[i] * shimmerLevel;
+            this.fdn.shimmerInR[i] = this.prevShimmerR[i] * shimmerLevel;
+        }
+
+        // ── 4. FDN Reverb (with shimmer injection) ──
+        this.fdn.process(wetL, wetR, numSamples);
+
+        // ── 5. Pitch Shift (FDN output → shimmer feedback) ──
+        const fdnOutL = this._fdnOutL;
+        const fdnOutR = this._fdnOutR;
+        for (let i = 0; i < numSamples; i++) {
+            fdnOutL[i] = wetL[i];
+            fdnOutR[i] = wetR[i];
+        }
+        this.pitchL.process(fdnOutL, this.shimmerBufL, numSamples);
+        this.pitchR.process(fdnOutR, this.shimmerBufR, numSamples);
+
+        // ── 6. Shimmer LP (adaptive one-pole lowpass after pitch shifting) ──
+        // Cutoff: 6kHz→2.5kHz as octUp increases (tames harsh shimmer harmonics)
+        for (let i = 0; i < numSamples; i++) {
+            this.shimmerLpStateL = (1.0 - shimmerLpCoeff) * this.shimmerBufL[i]
+                + shimmerLpCoeff * this.shimmerLpStateL;
+            this.shimmerBufL[i] = this.shimmerLpStateL;
+
+            this.shimmerLpStateR = (1.0 - shimmerLpCoeff) * this.shimmerBufR[i]
+                + shimmerLpCoeff * this.shimmerLpStateR;
+            this.shimmerBufR[i] = this.shimmerLpStateR;
+        }
+
+        // ── 7. Energy Limiter (prevents shimmer runaway, uses shimmerLevel) ──
+        // Threshold inversely related to shimmerLevel for tighter control at high levels
+        const limiterThreshold = 0.9 - shimmerLevel * 0.3; // 0.9→0.6
+        this.energyLimiter.process(
+            this.shimmerBufL, this.shimmerBufR, numSamples,
+            Math.max(0.3, limiterThreshold));
+
+        // ── 8. Store shimmer for next block ──
+        for (let i = 0; i < numSamples; i++) {
+            this.prevShimmerL[i] = this.shimmerBufL[i];
+            this.prevShimmerR[i] = this.shimmerBufR[i];
+        }
+
+        // ── 9. TubeSaturation (warmth: tube comp → saturation → HF rolloff) ──
+        this.tubeSaturation.process(wetL, wetR, numSamples);
+
+        // ── 10. TiltEQ (tone: first-order crossover tilt at 1kHz) ──
+        this.tiltEQ.process(wetL, wetR, numSamples);
+
+        // ── 11. Stereo Width (mid/side encoding) ──
+        this.stereoWidth.process(wetL, wetR, numSamples, stereoWidth);
+
+        // ── 12. Wet Gain (-4.5 dB) ──
+        for (let i = 0; i < numSamples; i++) {
+            wetL[i] *= WET_GAIN;
+            wetR[i] *= WET_GAIN;
+        }
+
+        // ── 13. Equal-power dry/wet mix (quadratic taper) ──
+        const mixTapered = mix * mix;
+        const dryGain = Math.cos(mixTapered * HALF_PI);
+        const wetGain = Math.sin(mixTapered * HALF_PI);
+
+        for (let i = 0; i < numSamples; i++) {
+            outL[i] = dryL[i] * dryGain + wetL[i] * wetGain;
+            outR[i] = dryR[i] * dryGain + wetR[i] * wetGain;
+        }
+
+        // ── 14. Output HPF (20 Hz high-pass to remove DC / sub rumble) ──
+        for (let i = 0; i < numSamples; i++) {
+            const inSampleL = outL[i];
+            const inSampleR = outR[i];
+            this.hpfPrevOutL = this.hpfR * this.hpfPrevOutL
+                + inSampleL - this.hpfPrevInL;
+            this.hpfPrevInL = inSampleL;
+            outL[i] = this.hpfPrevOutL;
+
+            this.hpfPrevOutR = this.hpfR * this.hpfPrevOutR
+                + inSampleR - this.hpfPrevInR;
+            this.hpfPrevInR = inSampleR;
+            outR[i] = this.hpfPrevOutR;
+        }
+
+        // ── 15. Output Limiter (peak envelope with fast attack / slow release) ──
+        for (let i = 0; i < numSamples; i++) {
+            const peak = Math.max(Math.abs(outL[i]), Math.abs(outR[i]));
+            if (peak > this.limiterEnv)
+                this.limiterEnv = 0.999 * this.limiterEnv + 0.001 * peak; // ~1ms attack
+            else
+                this.limiterEnv = 0.9999 * this.limiterEnv + 0.0001 * peak; // ~10ms release
+
+            if (this.limiterEnv > 0.92) {
+                const g = 0.92 / this.limiterEnv;
+                outL[i] *= g;
+                outR[i] *= g;
+            }
+        }
+
+        return true;
+    }
+}
+
+registerProcessor('drift-reverb', GlowReverbProcessor);


### PR DESCRIPTION
Replaces the home page at pebaum.github.io with a structural port of the Reverie plugin (v0.11.0-b), running as a self-evolving generative unit rather than a static slider stack.

## What's new

**Generative behaviour.** On every page load the 9 reverb-related front knobs (immersion, distance, expanse, shimmer/feedback, mod depth, glow, ascend, descend, drift) randomize within musically-sensible ranges; IN and OUT stay at unity. From there a slow drift loop re-rolls 3–6 of those targets every 90–240 s with a 50 ms smoothing tick (α = 0.0008 ≈ 62 s time constant), offset from the existing 2–6 min key/mode cadence so the two systems desynchronise. Values never settle — the page evolves continuously in the background.

**Front panel only.** No advanced/back panel. The 7 reverb sub-params (timbre, mod rate, diffusion, damping, HPF, LPF, early mod) are baked into the worklet at Reverie's exact defaults. Tintinnabuli engine, atmosphere drift, and tonality changes remain fully generative as on the previous home page.

## DSP port

`drift-worklet.js` (~2000 lines) is a hand-port from `Sonic Cascade/plugins/reverie/plugin/Source/dsp/`:

- **JPVerb reverb** — port of `DriftReverb.dsp` (Faust JPVerb fork): 6 modulation sources (4 incommensurate-rate sine LFOs + Butterworth-filtered noise each), `diffuser_aux` primitive (2×2 rotation, two `fdelay1a` allpass-interpolated delays per JOS3, recursive feedback with energy-conserving cos/sin normalisation, smooth_init 0.9999), the full topology (4 input diffusers + feedback through 5+5 invSqrt2 diffusers, 2+2 fb fdelay4 modulated delays, 2+2 prime fdelay1a delays at the .dsp's exact prime scales, Linkwitz-Riley 3-band filterbank, RT60-derived feedback gain).
- **TapeTransport** — full Revox A77 model: BC109C input electronics, NAB pre/de-emphasis, **2× oversampled Jiles-Atherton hysteresis with RK4 integrator**, tape-loss LPF, head-bump peakingEQ + dip biquads, 3-pt Lagrange-interpolated wow/flutter (6 sine LFOs + drift integrator), shaped tape hiss with modulation noise.
- **HeatChannel** — full per-channel port: cable LPF, tube saturation with grid current limiting + Miller capacitance + dual-RC sag + bias drift + 2× oversampling + sag-aware makeup, speaker breakup (thermal compression + voice-coil inductance + cone excursion + asymmetric soft-clip + Doppler distortion + cabinet resonance + slew-rate limit), signal-correlated tube crackle, Poisson dropouts, parallel-HF sizzle, ear compression (stapedius reflex + cochlear compression + temporary threshold shift).
- **DriftEffect** — orchestrator with both Kevin's and Peter's macro variants (piecewise lookups matching `DriftEffect.h` byte-for-byte), Tape Age EQ, RMS level matching, engagement fade, DC blocker.
- **SpectralPitchShifter** — 4096-pt phase vocoder with inline radix-2 Cooley-Tukey FFT, 1024-sample hop, octave-up + octave-down shifts with odd-bin blending, two instances per channel (ascend feeds back via shimmer, descend one-shot).
- **TiltEQ, GlowEffect, Butterworth HPF/LPF, 1 ms / 50 ms peak limiter** — line-for-line ports of the C++.

Signal flow exactly matches `DriftEngine::processBlock`.

## File changes

- `index.html` — replaced (old v29 glow-reverb home page → new Reverie port).
- `drift-worklet.js` — replaced (old v29 port → new full-DSP port, registers as `drift-reverb`).
- `drift-new.html` — deleted (promoted to `index.html`).
- `drift-worklet-new.js` — deleted (promoted to `drift-worklet.js`).

## Test plan

- [ ] Pull the branch locally and serve from your existing server. Hard-reload `pebaum.github.io/index.html` in a fresh tab.
- [ ] Verify ENTER overlay engages; visualization animates; voices fire; key/mode/atmosphere drift over time as before.
- [ ] Watch front-panel slider positions for ~5 minutes — they should creep continuously.
- [ ] Compare audible character against the actual Reverie plugin at matching settings.
- [ ] Pause/restart works without leaks; AudioContext closes cleanly on restart.

## Notes

- Performance: the full DSP (2× oversampled J-A hysteresis with RK4, 14 diffusers, 4 FFT pitch shifters, full Heat chain) is heavier than the previous v29 port. On underpowered devices the AudioWorklet deadline may be missed — performance optimisation is a follow-up if needed.
- DSP fidelity gaps are limited to algorithm-level translations (e.g., JPVerb prime-delay smoothing, J-A hard clamp) where the source already had numerical safety; the structure, parameter set, defaults, and signal flow match the C++ exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)