### PR TITLE
Title page "Peter Baumgartner" (drop "Reverie (experimental)")

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Peter Baumgartner — Reverie (experimental)</title>
+    <title>Peter Baumgartner</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;700&display=swap" rel="stylesheet">


### PR DESCRIPTION
## Summary

- Browser tab title was `Peter Baumgartner — Reverie (experimental)`. Now just `Peter Baumgartner`.

This commit was originally pushed to [#50](https://github.com/pebaum/pebaum.github.io/pull/50) but GitHub's PR head sync stalled and #50 merged on the previous tip — so the title change never landed. This PR carries the orphan commit forward.

## Test plan

- [ ] After deploy, the browser tab and bookmark name read `Peter Baumgartner`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)